### PR TITLE
Added cloudresourcemanager API to terraform config

### DIFF
--- a/terraform/feeds.tf
+++ b/terraform/feeds.tf
@@ -15,6 +15,7 @@ locals {
     "cloudbuild.googleapis.com",
     "run.googleapis.com",
     "cloudscheduler.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
Quick and easy. Noticed in [this build](https://github.com/ossf/package-feeds/runs/1795953113?check_suite_focus=true) that we're not adding the cloudresourcemanager API via Terraform.

This is all just some trial and error 😛 