### PR TITLE
Setup infrastructure for the npm feed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
         cd feeds/pypi;
         gcloud builds submit --tag gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-pypi;
         cd ../../;
+        gcloud builds submit --tag gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-npm;
+        cd ../../;
 
     - name: Terraform Init
       run: terraform init
@@ -68,4 +70,10 @@ jobs:
           --platform managed \
           --region us-central1 \
           --image gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-pypi;
+        cd ../../;
+        gcloud run deploy \
+          npm-run-srv \
+          --platform managed \
+          --region us-central1 \
+          --image gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-npm;
         cd ../../;

--- a/terraform/npm.tf
+++ b/terraform/npm.tf
@@ -1,0 +1,31 @@
+resource "google_cloud_scheduler_job" "trigger-npm-scheduler" {
+  name        = "trigger-npm-scheduler"
+  description = "The scheduler that triggers fetching new npm packages"
+  schedule    = "*/5 * * * *"
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloud_run_service.run-npm.status[0].url
+
+    oidc_token {
+      service_account_email = google_service_account.run-invoker-account.email
+    }
+  }
+}
+
+resource "google_cloud_run_service" "run-npm" {
+  name     = "npm-run-srv"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/${var.project}/feeds-npm"
+        env {
+          name  = "OSSMALWARE_TOPIC_URL"
+          value = "gcppubsub://${google_pubsub_topic.feed-topic.id}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR sets up the Terraform and Cloud Run scaffolding for the npm feed introduced in #16.