### PR TITLE
Fix npm path when building Cloud Run images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
         cd feeds/pypi;
         gcloud builds submit --tag gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-pypi;
         cd ../../;
+        cd feeds/npm;
         gcloud builds submit --tag gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-npm;
         cd ../../;
 
@@ -71,6 +72,7 @@ jobs:
           --region us-central1 \
           --image gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/feeds-pypi;
         cd ../../;
+        cd feeds/npm;
         gcloud run deploy \
           npm-run-srv \
           --platform managed \


### PR DESCRIPTION
Looks like PR #18 was merged with a small error when building cloud images. This should be fixed now. 😄 

(Note: I want to make sure that checks pass before merging to catch any other issues)