### PR TITLE
Feature - Included settings for dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "go:modules"
+    directory: "/scheduler"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "go:modules"
+    directory: "/analysis"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "go:modules"
+    directory: "/feeds/pypi"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "go:modules"
+    directory: "/feeds/npm"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/feeds/pypi"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/feeds/npm"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable dependabot.

To enable this setting it has to be turned on here  https://github.com/ossf/package-feeds/security similar to this

![image](https://user-images.githubusercontent.com/172697/106544223-2c5c7300-64d5-11eb-8522-841f219a481d.png)
