### PR TITLE
Tweak README to note its focus on malware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package Feeds
 
-This repo contains a few subprojects to aid in the analysis of open source packages.
+This repo contains a few subprojects to aid in the analysis of open source packages, in particular to look for malicious software.
 
 These are:
 


### PR DESCRIPTION
This commit tweaks the README to note this project's focus on malware.

Someone who just reads the first line will confuse this project with other projects that *also* analyze OSS & report information (such as the scorecard).
What's different about this project is its capturing of data to, among other things, detect some malware.
So let's make that clear from the beginning!