### PR TITLE
Fix - dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     directory: "/feeds/npm"
     schedule:
       interval: "daily"
+ - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- The dependabot was in the wrong folder.
- Included dependabot settings for githubactions