### PR TITLE
Restrict deploy job to only run on push.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: terraform fmt
+      run: terraform fmt -check
+      working-directory: ./terraform
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
 
 jobs:
   terraform:


### PR DESCRIPTION
The deploy workflow is causing more headaches than value. The value we'd get from a PR on the local repo is the output of `terraform plan` which is nice, but for every other run (e.g. from a fork) it causes failures.

This updates the workflow to only run on pushes. I've also added the `terraform fmt` check to occur during every push or PR.