### PR TITLE
Add back the pubsub URL prefix.

### DIFF
--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -23,7 +23,7 @@ resource "google_cloud_run_service" "run-scheduler" {
         image = "gcr.io/${var.project}/feeds-${var.pkg-ecosystem}"
         env {
           name  = "OSSMALWARE_TOPIC_URL"
-          value = var.pubsub-topic-feed-id
+          value = "gcppubsub://${var.pubsub-topic-feed-id}"
         }
       }
     }


### PR DESCRIPTION
Scheduler jobs are failing with: "no scheme in URL "projects/ossf-malware-analysis/topics/feed-topic""