### PR TITLE
Fix- dependabot github actions folder location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Fixed the incorrect dependabot github actions folder location