### PR TITLE
Leverage goroutines for processing feeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         go-version: 1.15
 
+    - name: Run tests
+      run: go test -v ./...
+
     - name: npm feeds build
       run: |
            cd feeds/npm/

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -24,10 +24,12 @@ type FeedHandler struct {
 
 func (handler *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cutoff := time.Now().UTC().Add(-delta)
-	pkgs, err := handler.scheduler.Poll(cutoff)
-	if err != nil {
-		log.Errorf("error polling for new packages: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	pkgs, errs := handler.scheduler.Poll(cutoff)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Errorf("error polling for new packages: %v", err)
+		}
+		http.Error(w, "error fetching packages - see logs for more information", http.StatusInternalServerError)
 		return
 	}
 	for _, pkg := range pkgs {
@@ -59,7 +61,7 @@ func main() {
 	} else {
 		pub, err = publisher.NewPubSub(context.TODO(), pubURL)
 		if err != nil {
-			log.Fatal("error creating gcp pubsub topic with url %q: %v", pubURL, err)
+			log.Fatalf("error creating gcp pubsub topic with url %q: %v", pubURL, err)
 		}
 	}
 	log.Infof("using %q publisher", pub.Name())

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -29,8 +29,6 @@ func (handler *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, err := range errs {
 			log.Errorf("error polling for new packages: %v", err)
 		}
-		http.Error(w, "error fetching packages - see logs for more information", http.StatusInternalServerError)
-		return
 	}
 	for _, pkg := range pkgs {
 		log.WithFields(log.Fields{

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -30,7 +30,9 @@ func (handler *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Errorf("error polling for new packages: %v", err)
 		}
 	}
+	processed := 0
 	for _, pkg := range pkgs {
+		processed++
 		log.WithFields(log.Fields{
 			"name":         pkg.Name,
 			"feed":         pkg.Type,
@@ -48,6 +50,11 @@ func (handler *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if len(errs) > 0 {
+		http.Error(w, "error polling for packages - see logs for more information", http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte(fmt.Sprintf("%d packages processed", processed)))
 }
 
 func main() {

--- a/feeds/scheduler/scheduler_test.go
+++ b/feeds/scheduler/scheduler_test.go
@@ -1,0 +1,54 @@
+package scheduler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+)
+
+type mockFeed struct {
+	packages []*feeds.Package
+	err      error
+}
+
+func (mf mockFeed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+	return mf.packages, mf.err
+}
+
+func TestPoll(t *testing.T) {
+	packageErr := errors.New("error fetching packages")
+	registry := map[string]feeds.ScheduledFeed{
+		"foo-feed": mockFeed{
+			packages: []*feeds.Package{
+				{Name: "foo-package-1"},
+				{Name: "foo-package-2"},
+			},
+		},
+		"err-feed": mockFeed{
+			err: packageErr,
+		},
+	}
+
+	sched := &Scheduler{
+		registry: registry,
+	}
+	gotPackages, gotErrs := sched.Poll(time.Now())
+	if len(gotErrs) != 1 {
+		t.Fatalf("incorrect number of errors received. expected %d got %d", 1, len(gotErrs))
+	}
+	if gotErrs[0] != packageErr {
+		t.Fatalf("incorrect error received. expected %v got %v", packageErr, gotErrs[0])
+	}
+	feed := registry["foo-feed"].(mockFeed)
+	expectedPackages := feed.packages
+	if len(gotPackages) != len(expectedPackages) {
+		t.Fatalf("incorrect number of packages received. expected %d got %d", len(expectedPackages), len(gotPackages))
+	}
+	for i, pkg := range gotPackages {
+		if pkg.Name != expectedPackages[i].Name {
+			t.Fatalf("unexpected packages received. expected %#v got %#v", gotPackages, expectedPackages)
+		}
+	}
+}


### PR DESCRIPTION
This PR implements the previous suggestion in #53 to use goroutines when fetching new packages.

Worth noting I've decided to just log errors for now instead of failing closed. That way if one feed is broken, we still send results for the rest of them.