### PR TITLE
Feat - this adds basic support for packagist

### DIFF
--- a/feeds/packagist/doc.go
+++ b/feeds/packagist/doc.go
@@ -1,0 +1,3 @@
+// package packagist fetches packages updates from the API and static files from packagist for getting the version information.
+// We choose the API instead of the RSS feed as it includes both newly created packages but also updated packages.
+package packagist

--- a/feeds/packagist/packagist.go
+++ b/feeds/packagist/packagist.go
@@ -1,0 +1,114 @@
+package packagist
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+)
+
+const FeedName = "packagist"
+
+var (
+	updateHost  = "https://packagist.org"
+	versionHost = "https://repo.packagist.org"
+)
+
+type response struct {
+	Actions   []actions `json:"actions"`
+	Timestamp int64     `json:"timestamp"`
+}
+type actions struct {
+	Type    string `json:"type"`
+	Package string `json:"package"`
+	Time    int64  `json:"time"`
+}
+
+type Feed struct{}
+
+func fetchPackages(since time.Time) ([]actions, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/metadata/changes.json", updateHost), nil)
+	if err != nil {
+		return nil, err
+	}
+	values := request.URL.Query()
+	sinceStr := strconv.FormatInt(since.Unix()*10000, 10)
+	values.Add("since", sinceStr)
+	request.URL.RawQuery = values.Encode()
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	apiResponse := &response{}
+	err = json.NewDecoder(resp.Body).Decode(apiResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiResponse.Actions, nil
+}
+
+func fetchVersionInformation(cutoff time.Time, action actions) ([]*feeds.Package, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(fmt.Sprintf("%s/p2/%s.json", versionHost, action.Package))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	versionResponse := &packages{}
+	err = json.NewDecoder(resp.Body).Decode(versionResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs := []*feeds.Package{}
+	for pkgName, versions := range versionResponse.Packages {
+		for _, version := range versions {
+			if version.Time.Before(cutoff) {
+				continue
+			}
+			pkgs = append(pkgs, &feeds.Package{
+				Name:        pkgName,
+				Version:     version.Version,
+				CreatedDate: version.Time,
+				Type:        FeedName,
+			})
+		}
+	}
+
+	return pkgs, nil
+}
+
+// Latest returns all package updates of packagist packages since cutoff
+func (f Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+	pkgs := []*feeds.Package{}
+	packages, err := fetchPackages(cutoff)
+	if err != nil {
+		return nil, err
+	}
+	for _, pkg := range packages {
+		if time.Unix(pkg.Time, 0).Before(cutoff) {
+			continue
+		}
+		if pkg.Type == "delete" {
+			continue
+		}
+		updates, err := fetchVersionInformation(cutoff, pkg)
+		if err != nil {
+			return nil, fmt.Errorf("error in fetching version information: %w", err)
+		}
+		pkgs = append(pkgs, updates...)
+	}
+	return pkgs, nil
+}

--- a/feeds/packagist/packagist_test.go
+++ b/feeds/packagist/packagist_test.go
@@ -1,0 +1,62 @@
+package packagist
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetch(t *testing.T) {
+	srv := serverMock()
+	defer srv.Close()
+	updateHost = srv.URL
+	versionHost = srv.URL
+	feed := Feed{}
+	cutoff := time.Unix(1614513658, 0)
+	latest, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("got error: %s", err)
+	}
+	if len(latest) == 0 {
+		t.Fatalf("did not get any updates")
+	}
+	for _, pkg := range latest {
+		if pkg.CreatedDate.Before(cutoff) {
+			t.Fatalf("package returned that was updated before cutoff %f", pkg.CreatedDate.Sub(cutoff).Minutes())
+		}
+		if pkg.Name == "to-delete/deleted-package" {
+			t.Fatalf("pkg to-delete/deleted-package was deleted and should not be included here")
+		}
+	}
+}
+
+func serverMock() *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/p2/", versionMock)
+	handler.HandleFunc("/metadata/changes.json", changesMock)
+	srv := httptest.NewServer(handler)
+
+	return srv
+}
+func changesMock(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("since") == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"Invalid or missing \u0022since\u0022 query parameter, make sure you store the timestamp at the initial point you started mirroring, then send that to begin receiving changes, e.g. https:\/\/packagist.org\/metadata\/changes.json?since=16145146222715 for example.","timestamp":16145146222715}`))
+	}
+	_, _ = w.Write([]byte(`{"actions":[{"type":"delete","package":"to-delete/deleted-package","time":1614513806},{"type":"update","package":"ossf/package","time":1614514502},{"type":"update","package":"ossf/package~dev","time":1614514502}],"timestamp":16145145025048}`))
+}
+
+func versionMock(w http.ResponseWriter, r *http.Request) {
+	m := map[string]string{
+		"/p2/ossf/package.json":     `{"packages":{"ossf/package":[{"name":"ossf/package","description":"Lorem Ipsum","keywords":["Lorem Ipsum 1","Lorem Ipsum 2"],"homepage":"","version":"v1.0.0","version_normalized":"1.0.0.0","license":["MIT"],"authors":[{"name":"John Doe","email":"john.doe@local"}],"source":{"type":"git","url":"https://github.com/ossf/package.git","reference":"c3afaa087afb42bfaf40fc3cda1252cd9a653d7f"},"dist":{"type":"zip","url":"https://api.github.com/repos/ossf/package/zipball/c3afaa087afb42bfaf40fc3cda1252cd9a653d7f","reference":"c3afaa087afb42bfaf40fc3cda1252cd9a653d7f","shasum":""},"type":"library","time":"2021-02-28T12:20:03+00:00","autoload":{"psr-4":{"package\\":"src/"}},"require":{"php":"^8.0","guzzlehttp/guzzle":"^7.2"},"require-dev":{"codeception/codeception":"^4.1","codeception/module-phpbrowser":"^1.0.0","codeception/module-asserts":"^1.0.0","hoa/console":"^3.17"},"support":{"issues":"https://github.com/ossf/package/issues","source":"https://github.com/ossf/package/tree/v1.0.0"}}]},"minified":"composer/2.0"}`,
+		"/p2/ossf/package~dev.json": `{"packages":{"ossf/package":[{"name":"ossf/package","description":"Lorem Ipsum","keywords":["Lorem Ipsum 1","Lorem Ipsum 2"],"homepage":"","version":"dev-master","version_normalized":"dev-master","license":["MIT"],"authors":[{"name":"John Doe","email":"john.doe@local"}],"source":{"type":"git","url":"https://github.com/ossf/package.git","reference":"c3afaa087afb42bfaf40fc3cda1252cd9a653d7f"},"dist":{"type":"zip","url":"https://api.github.com/repos/ossf/package/zipball/c3afaa087afb42bfaf40fc3cda1252cd9a653d7f","reference":"c3afaa087afb42bfaf40fc3cda1252cd9a653d7f","shasum":""},"type":"library","time":"2021-02-28T12:20:03+00:00","autoload":{"psr-4":{"package\\":"src/"}},"default-branch":true,"require":{"php":"^8.0","guzzlehttp/guzzle":"^7.2"},"require-dev":{"codeception/codeception":"^4.1","codeception/module-phpbrowser":"^1.0.0","codeception/module-asserts":"^1.0.0","hoa/console":"^3.17"},"support":{"issues":"https://github.com/ossf/package/issues","source":"https://github.com/ossf/package/tree/v1.0.0"}}]},"minified":"composer/2.0"}`,
+	}
+	for u, response := range m {
+		if u == r.URL.String() {
+			_, _ = w.Write([]byte(response))
+			return
+		}
+	}
+	http.NotFound(w, r)
+}

--- a/feeds/packagist/version.go
+++ b/feeds/packagist/version.go
@@ -1,0 +1,14 @@
+package packagist
+
+import "time"
+
+type versionInfo struct {
+	Version           string    `json:"version"`
+	VersionNormalized string    `json:"version_normalized"`
+	License           []string  `json:"license,omitempty"`
+	Time              time.Time `json:"time"`
+	Name              string    `json:"name,omitempty"`
+}
+type packages struct {
+	Packages map[string][]versionInfo `json:"packages"`
+}

--- a/feeds/scheduler/scheduler.go
+++ b/feeds/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ossf/package-feeds/feeds/crates"
 	"github.com/ossf/package-feeds/feeds/goproxy"
 	"github.com/ossf/package-feeds/feeds/npm"
+	"github.com/ossf/package-feeds/feeds/packagist"
 	"github.com/ossf/package-feeds/feeds/pypi"
 	"github.com/ossf/package-feeds/feeds/rubygems"
 	log "github.com/sirupsen/logrus"
@@ -20,11 +21,12 @@ type Scheduler struct {
 // New returns a new Scheduler with available feeds registered
 func New() *Scheduler {
 	registry := map[string]feeds.ScheduledFeed{
-		pypi.FeedName:     pypi.Feed{},
-		npm.FeedName:      npm.Feed{},
-		rubygems.FeedName: rubygems.Feed{},
-		crates.FeedName:   crates.Feed{},
+		crates.FeedName:    crates.Feed{},
 		goproxy.FeedName:  goproxy.Feed{},
+		npm.FeedName:       npm.Feed{},
+		packagist.FeedName: packagist.Feed{},
+		pypi.FeedName:      pypi.Feed{},
+		rubygems.FeedName:  rubygems.Feed{},
 	}
 	s := &Scheduler{
 		registry: registry,


### PR DESCRIPTION
Hey,

Here is a very simple implementation for PHP feeds.

Couple of questions before I complete it:
- I would like to add tests and mock the http requests with: https://github.com/h2non/gock but did not wanna just include it. How do you feel about adding this kind of dependency?
- Currently dev updates are included and those are created when someone pushes a commit into a branch but does not add a tag. So there are versions like dev-<branch-name> (e.g. dev-master, dev-feat-packagist) should those be included? If not they can be easily filtered out.
- how should I document why I choose the api over the rss feed? (I did it because it is one endpoint for newly created packages and updates instead of 2 different rss feeds) 

closes #30 