### PR TITLE
Initial NuGet feed support

### DIFF
--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -11,8 +11,14 @@ import (
 
 const (
 	FeedName           = "nuget"
-	feedURL            = "https://api.nuget.org/v3/index.json"
 	catalogServiceType = "Catalog/3.0.0"
+)
+
+var (
+	feedURL    = "https://api.nuget.org/v3/index.json"
+	httpClient = http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 type serviceIndex struct {
@@ -44,10 +50,6 @@ type nugetPackageDetails struct {
 	PackageID string    `json:"id"`
 	Version   string    `json:"version"`
 	Created   time.Time `json:"published"`
-}
-
-var httpClient = http.Client{
-	Timeout: 10 * time.Second,
 }
 
 func fetchCatalogService() (*nugetService, error) {

--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -15,7 +15,7 @@ const (
 	catalogServiceType = "Catalog/3.0.0"
 )
 
-type nugetServiceIndex struct {
+type serviceIndex struct {
 	Services []*nugetService `json:"resources"`
 }
 
@@ -46,27 +46,25 @@ type nugetPackageDetails struct {
 	Created   time.Time `json:"published"`
 }
 
-var httpClient http.Client = http.Client{
+var httpClient = http.Client{
 	Timeout: 10 * time.Second,
 }
 
 func fetchCatalogService() (*nugetService, error) {
 	resp, err := httpClient.Get(feedURL)
-
 	if err != nil {
 		return nil, err
 	}
 
 	defer resp.Body.Close()
 
-	serviceIndex := &nugetServiceIndex{}
-	err = json.NewDecoder(resp.Body).Decode(serviceIndex)
-
+	directory := &serviceIndex{}
+	err = json.NewDecoder(resp.Body).Decode(directory)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, service := range serviceIndex.Services {
+	for _, service := range directory.Services {
 		if service.Type == catalogServiceType {
 			return service, nil
 		}
@@ -77,7 +75,6 @@ func fetchCatalogService() (*nugetService, error) {
 
 func fetchCatalogPages(catalogURL string) ([]*catalogPage, error) {
 	resp, err := httpClient.Get(catalogURL)
-
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +83,6 @@ func fetchCatalogPages(catalogURL string) ([]*catalogPage, error) {
 
 	c := &catalog{}
 	err = json.NewDecoder(resp.Body).Decode(c)
-
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +92,6 @@ func fetchCatalogPages(catalogURL string) ([]*catalogPage, error) {
 
 func fetchCatalogPage(url string) ([]*catalogLeaf, error) {
 	resp, err := httpClient.Get(url)
-
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +100,6 @@ func fetchCatalogPage(url string) ([]*catalogLeaf, error) {
 
 	page := &catalogPage{}
 	err = json.NewDecoder(resp.Body).Decode(page)
-
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +109,6 @@ func fetchCatalogPage(url string) ([]*catalogLeaf, error) {
 
 func fetchPackageInfo(url string) (*nugetPackageDetails, error) {
 	resp, err := httpClient.Get(url)
-
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +117,6 @@ func fetchPackageInfo(url string) (*nugetPackageDetails, error) {
 
 	packageDetail := &nugetPackageDetails{}
 	err = json.NewDecoder(resp.Body).Decode(packageDetail)
-
 	if err != nil {
 		return nil, err
 	}
@@ -141,13 +133,11 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}
 
 	catalogService, err := fetchCatalogService()
-
 	if err != nil {
 		return nil, err
 	}
 
 	catalogPages, err := fetchCatalogPages(catalogService.URI)
-
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +148,6 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 		}
 
 		page, err := fetchCatalogPage(catalogPage.URI)
-
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +162,6 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 			}
 
 			packageCreationDetail, err := fetchPackageInfo(catalogLeafNode.URI)
-
 			if err != nil {
 				return nil, err
 			}

--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -1,0 +1,195 @@
+package nuget
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+)
+
+const (
+	FeedName           = "nuget"
+	feedURL            = "https://api.nuget.org/v3/index.json"
+	catalogServiceType = "Catalog/3.0.0"
+)
+
+type nugetServiceIndex struct {
+	Services []*nugetService `json:"resources"`
+}
+
+type nugetService struct {
+	URI  string `json:"@id"`
+	Type string `json:"@type"`
+}
+
+type catalog struct {
+	Pages []*catalogPage `json:"items"`
+}
+
+type catalogPage struct {
+	URI      string         `json:"@id"`
+	Created  time.Time      `json:"commitTimeStamp"`
+	Packages []*catalogLeaf `json:"items"`
+}
+
+type catalogLeaf struct {
+	URI            string    `json:"@id"`
+	CatalogCreated time.Time `json:"commitTimeStamp"`
+	Type           string    `json:"@type"`
+}
+
+type nugetPackageDetails struct {
+	PackageID string    `json:"id"`
+	Version   string    `json:"version"`
+	Created   time.Time `json:"published"`
+}
+
+var httpClient http.Client = http.Client{
+	Timeout: 10 * time.Second,
+}
+
+func fetchCatalogService() (*nugetService, error) {
+	resp, err := httpClient.Get(feedURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	serviceIndex := &nugetServiceIndex{}
+	err = json.NewDecoder(resp.Body).Decode(serviceIndex)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, service := range serviceIndex.Services {
+		if service.Type == catalogServiceType {
+			return service, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not locate catalog service for nuget feed (%s)", feedURL)
+}
+
+func fetchCatalogPages(catalogURL string) ([]*catalogPage, error) {
+	resp, err := httpClient.Get(catalogURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	c := &catalog{}
+	err = json.NewDecoder(resp.Body).Decode(c)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Pages, nil
+}
+
+func fetchCatalogPage(url string) ([]*catalogLeaf, error) {
+	resp, err := httpClient.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	page := &catalogPage{}
+	err = json.NewDecoder(resp.Body).Decode(page)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.Packages, nil
+}
+
+func fetchPackageInfo(url string) (*nugetPackageDetails, error) {
+	resp, err := httpClient.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	packageDetail := &nugetPackageDetails{}
+	err = json.NewDecoder(resp.Body).Decode(packageDetail)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return packageDetail, nil
+}
+
+type Feed struct{}
+
+// Latest will parse all creation events for packages in the nuget.org catalog feed
+// for packages that have been published since the cutoff
+// https://docs.microsoft.com/en-us/nuget/api/catalog-resource
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+	pkgs := []*feeds.Package{}
+
+	catalogService, err := fetchCatalogService()
+
+	if err != nil {
+		return nil, err
+	}
+
+	catalogPages, err := fetchCatalogPages(catalogService.URI)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, catalogPage := range catalogPages {
+		if catalogPage.Created.Before(cutoff) {
+			continue
+		}
+
+		page, err := fetchCatalogPage(catalogPage.URI)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, catalogLeafNode := range page {
+			if catalogLeafNode.CatalogCreated.Before(cutoff) {
+				continue
+			}
+
+			if catalogLeafNode.Type != "nuget:PackageDetails" {
+				continue // Not currently interested in package deletion events
+			}
+
+			packageCreationDetail, err := fetchPackageInfo(catalogLeafNode.URI)
+
+			if err != nil {
+				return nil, err
+			}
+
+			if packageCreationDetail.Created.Before(cutoff) {
+				continue
+			}
+
+			pkgs = append(pkgs, &feeds.Package{
+				Name:        packageCreationDetail.PackageID,
+				CreatedDate: packageCreationDetail.Created,
+				Version:     packageCreationDetail.Version,
+				Type:        FeedName,
+			})
+		}
+	}
+
+	return pkgs, nil
+}

--- a/feeds/nuget/nuget_test.go
+++ b/feeds/nuget/nuget_test.go
@@ -1,0 +1,99 @@
+package nuget
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+var testEndpoint *url.URL
+
+func TestCanParseFeed(t *testing.T) {
+	srv := nugetAPIMock()
+
+	testEndpoint, _ = url.Parse(srv.URL)
+	feedURL = makeTestURL("v3/index.json")
+
+	sut := Feed{}
+	cutoff := time.Now().Add(-5 * time.Minute)
+
+	results, err := sut.Latest(cutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("1 result expected but %d retrieved", len(results))
+	}
+
+	const expectedName = "new.expected.package"
+	const expectedVersion = "0.0.1"
+	const expectedType = "nuget"
+	result := results[0]
+
+	if result.Name != expectedName {
+		t.Fatalf("expected %s but %s was retrieved", expectedName, result.Name)
+	}
+
+	if result.Version != expectedVersion {
+		t.Fatalf("expected version %s but %s was retrieved", expectedVersion, result.Version)
+	}
+
+	if result.Type != expectedType {
+		t.Fatalf("expected type %s but %s was retrieved", expectedType, result.Type)
+	}
+}
+
+func nugetAPIMock() *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v3/index.json", indexMock)
+	handler.HandleFunc("/v3/catalog0/index.json", catalogMock)
+	handler.HandleFunc("/v3/catalog0/page1.json", catalogPageMock)
+	handler.HandleFunc("/v3/catalog0/data/somecatalog/new.expected.package.0.0.1.json", packageDetailMock)
+
+	srv := httptest.NewServer(handler)
+	return srv
+}
+
+func indexMock(w http.ResponseWriter, r *http.Request) {
+	catalogEndpoint := makeTestURL("v3/catalog0/index.json")
+	response := fmt.Sprintf(`{"resources": [{"@id": "%s", "@type": "Catalog/3.0.0"}]}`, catalogEndpoint)
+
+	_, _ = w.Write([]byte(response))
+}
+
+func catalogMock(w http.ResponseWriter, r *http.Request) {
+	pageEndpoint := makeTestURL("v3/catalog0/page1.json")
+
+	response := fmt.Sprintf(`{"items": [{"@id": "%s", "commitTimeStamp": "%s"}]}`, pageEndpoint, time.Now().Format(time.RFC3339))
+
+	_, _ = w.Write([]byte(response))
+}
+
+func catalogPageMock(w http.ResponseWriter, r *http.Request) {
+	pkgAdded := "nuget:PackageDetails"
+	pkgDeleted := "nuget:PackageDelete"
+	pkgTemplate := `{"@id": "%s", "@type": "%s", "commitTimeStamp": "%s"}`
+
+	addedItem := fmt.Sprintf(pkgTemplate, makeTestURL("v3/catalog0/data/somecatalog/new.expected.package.0.0.1.json"), pkgAdded, time.Now().UTC().Format(time.RFC3339))
+	oldAddedItem := fmt.Sprintf(pkgTemplate, makeTestURL("v3/catalog0/data/somecatalog/old.not.expected.package.0.0.1.json"), pkgAdded, time.Now().UTC().Add(-10*time.Minute).Format(time.RFC3339))
+	deletedItem := fmt.Sprintf(pkgTemplate, makeTestURL("v3/catalog0/data/somecatalog/modified.not.expected.0.0.1.json"), pkgDeleted, time.Now().UTC().Format(time.RFC3339))
+
+	response := fmt.Sprintf(`{"items": [%s, %s, %s]}`, addedItem, deletedItem, oldAddedItem)
+
+	_, _ = w.Write([]byte(response))
+}
+
+func packageDetailMock(w http.ResponseWriter, r *http.Request) {
+	response := fmt.Sprintf(`{"id": "new.expected.package", "version": "0.0.1", "published": "%s"}`, time.Now().UTC().Add(-1*time.Minute).Format(time.RFC3339))
+
+	_, _ = w.Write([]byte(response))
+}
+
+func makeTestURL(suffix string) string {
+	path, _ := url.Parse(suffix)
+	return testEndpoint.ResolveReference(path).String()
+}

--- a/feeds/scheduler/scheduler.go
+++ b/feeds/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ossf/package-feeds/feeds/crates"
 	"github.com/ossf/package-feeds/feeds/goproxy"
 	"github.com/ossf/package-feeds/feeds/npm"
+	"github.com/ossf/package-feeds/feeds/nuget"
 	"github.com/ossf/package-feeds/feeds/pypi"
 	"github.com/ossf/package-feeds/feeds/rubygems"
 	log "github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ func New() *Scheduler {
 		rubygems.FeedName: rubygems.Feed{},
 		crates.FeedName:   crates.Feed{},
 		goproxy.FeedName:  goproxy.Feed{},
+		nuget.FeedName:    nuget.Feed{},
 	}
 	s := &Scheduler{
 		registry: registry,


### PR DESCRIPTION
Not sure if there's still interest in this, but this is a rough initial implementation of a nuget feed parser - which I think would close #31. This parser uses the [Catalog](https://docs.microsoft.com/en-us/nuget/api/catalog-resource) endpoint, which provides an append-only feed of nuget package operations performed against a nuget repository (in this case nuget.org).

Parsing the catalog feed is done as follows:

- Resolve the Catalog service endpoint from the [service endpoint](https://api.nuget.org/v3/index.json). This is not strictly necessary (could be hard coded to save a HTTP call), but allows this code to be pointed at any compliant NuGet v3 API
- Fetch the [catalog index document](https://api.nuget.org/v3/catalog0/index.json). This page contains pointers to the leaf catalog nodes.
- Fetch each [catalog leaf document](https://api.nuget.org/v3/catalog0/page12067.json) that has been modified since the cutoff. These documents contain a log of package updates, deletions, reindexings etc.
- For each update newer than the cutoff, fetch details for the package. This is necessary because packages [may be reflowed](https://docs.microsoft.com/en-us/nuget/api/catalog-resource#package-details-catalog-items) into the catalog after initial publication - so we fetch the actual publication date from the leaf detail document

There's definitely some room for optimisation around fetching the leaf pages/package information in parallel, but performance should hopefully be reasonable. Apologies in advance for my rusty golang skills - happy for this to be hacked about with/thrown away!