### PR TITLE
Add configuration options for scheduled-feed binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ infrastructure to study behavior of open source packages and to look for malicio
 We also hope that the components can be used independently, to provide package feeds or runtime
 behavior data for anyone interested.
 
+# Configuration
+
+A YAML configuration file can be provided with the following format:
+
+```
+enabled_feeds:
+- pypi
+- npm
+- goproxy
+- rubygems
+- crates
+
+publisher:
+  type: 'gcp_pubsub'
+  config:
+    url: "gcppubsub://foobar.com"
+
+http_port: 8080
+```
+
+To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+
+## Legacy Configuration
+
+Legacy configuration methods are still supported. By default, without a configuration file all feeds will be enabled. The environment variable `OSSMALWARE_TOPIC_URL` can be used to select the GCP pubsub publisher and `PORT` will configure the port for the HTTP server.
+
 # Contributing
 
 If you want to get involved or have ideas you'd like to chat about, we discuss this project in the [OSSF Securing Critical Projects Working Group](https://github.com/ossf/wg-securing-critical-projects) meetings.

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/ossf/package-feeds/feeds/scheduler"
 	"github.com/ossf/package-feeds/publisher"
+	"github.com/ossf/package-feeds/publisher/gcppubsub"
+	"github.com/ossf/package-feeds/publisher/stdout"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -62,9 +64,9 @@ func main() {
 	var pub publisher.Publisher
 	var err error
 	if pubURL == "" {
-		pub = publisher.NewStdoutPublisher()
+		pub = stdout.New()
 	} else {
-		pub, err = publisher.NewPubSub(context.TODO(), pubURL)
+		pub, err = gcppubsub.New(context.TODO(), pubURL)
 		if err != nil {
 			log.Fatalf("error creating gcp pubsub topic with url %q: %v", pubURL, err)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ossf/package-feeds/config"
+	"github.com/ossf/package-feeds/feeds/scheduler"
+	"github.com/ossf/package-feeds/publisher/stdout"
+)
+
+const (
+	TestConfigStr = `
+enabled_feeds:
+- rubygems
+- goproxy
+- npm
+
+publisher:
+  type: "gcp"
+  config:
+    endpoint: "https://foobaz.com"
+
+http_port: 8080
+`
+	TestConfigStrUnknownFeedType = `
+enabled_feeds:
+- foo
+`
+	TestConfigStrUnknownField = `
+foo:
+- bar
+- baz
+`
+)
+
+func TestDefault(t *testing.T) {
+	t.Parallel()
+
+	c := config.Default()
+	feeds, err := c.GetScheduledFeeds()
+	if err != nil {
+		t.Fatalf("failed to initialize feeds: %v", err)
+	}
+	_ = scheduler.New(feeds)
+}
+
+func TestGetScheduledFeeds(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewConfigFromBytes([]byte(TestConfigStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.EnabledFeeds) != 3 {
+		t.Fatalf("EnabledFeeds is expected to be 3 but was `%v`", len(c.EnabledFeeds))
+	}
+	feeds, err := c.GetScheduledFeeds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, val := range c.EnabledFeeds {
+		if _, ok := feeds[val]; !ok {
+			t.Errorf("expected `%v` feed was not found in scheduled feeds after GetScheduledFeeds()", val)
+		}
+	}
+}
+
+func TestLoadFeedConfigUnknownFeedType(t *testing.T) {
+	t.Parallel()
+
+	c, err := config.NewConfigFromBytes([]byte(TestConfigStrUnknownFeedType))
+	if err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+	_, err = c.GetScheduledFeeds()
+	if err == nil {
+		t.Error("unknown feed type was successfully parsed when it should've failed")
+	}
+}
+
+func TestPubConfigToPublisherStdout(t *testing.T) {
+	t.Parallel()
+
+	c := config.PublisherConfig{
+		Type: stdout.PublisherType,
+	}
+	pub, err := c.ToPublisher(context.TODO())
+	if err != nil {
+		t.Fatal("failed to create stdout publisher from config")
+	}
+	if pub.Name() != stdout.PublisherType {
+		t.Errorf("stdout sub config produced a publisher with an unexpected name: '%v' != '%v'",
+			pub.Name(), stdout.PublisherType)
+	}
+}
+
+func TestStrictConfigDecoding(t *testing.T) {
+	t.Parallel()
+
+	_, err := config.NewConfigFromBytes([]byte(TestConfigStrUnknownField))
+	if err == nil {
+		t.Fatal("config successfully parsed despite invalid top level configuration field")
+	}
+}

--- a/config/scheduledfeed.go
+++ b/config/scheduledfeed.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/feeds/crates"
+	"github.com/ossf/package-feeds/feeds/goproxy"
+	"github.com/ossf/package-feeds/feeds/npm"
+	"github.com/ossf/package-feeds/feeds/nuget"
+	"github.com/ossf/package-feeds/feeds/packagist"
+	"github.com/ossf/package-feeds/feeds/pypi"
+	"github.com/ossf/package-feeds/feeds/rubygems"
+	"github.com/ossf/package-feeds/publisher"
+	"github.com/ossf/package-feeds/publisher/gcppubsub"
+	"github.com/ossf/package-feeds/publisher/stdout"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// Loads a ScheduledFeedConfig struct from a yaml config file
+func FromFile(configPath string) (*ScheduledFeedConfig, error) {
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConfigFromBytes(data)
+}
+
+// Loads a ScheduledFeedConfig struct from a yaml bytes
+func NewConfigFromBytes(bytes []byte) (*ScheduledFeedConfig, error) {
+	config := Default()
+
+	err := unmarshalStrict(bytes, config)
+	if err != nil {
+		return nil, err
+	}
+	config.applyEnvVars()
+
+	return config, nil
+}
+
+// Applies environment variables to the configuration
+func (config *ScheduledFeedConfig) applyEnvVars() {
+	// Support legacy env var definition for gcp pub sub.
+	pubURL := os.Getenv("OSSMALWARE_TOPIC_URL")
+	if pubURL != "" {
+		config.PubConfig = PublisherConfig{
+			Type: gcppubsub.PublisherType,
+			Config: map[string]interface{}{
+				"url": pubURL,
+			},
+		}
+	}
+
+	portStr, portProvided := os.LookupEnv("PORT")
+	port, err := strconv.Atoi(portStr)
+
+	if portProvided && err == nil {
+		config.HttpPort = port
+	}
+}
+
+func AddTo(ls *[]int, value int) {
+	*ls = append(*ls, value)
+}
+
+// Constructs a map of ScheduledFeeds to enable based on the EnabledFeeds provided from configuration, indexed by the feed type.
+func (sConfig *ScheduledFeedConfig) GetScheduledFeeds() (map[string]feeds.ScheduledFeed, error) {
+	var err error
+	scheduledFeeds := map[string]feeds.ScheduledFeed{}
+	for _, entry := range sConfig.EnabledFeeds {
+		switch entry {
+		case crates.FeedName:
+			scheduledFeeds[entry] = crates.Feed{}
+		case goproxy.FeedName:
+			scheduledFeeds[entry] = goproxy.Feed{}
+		case npm.FeedName:
+			scheduledFeeds[entry] = npm.Feed{}
+		case nuget.FeedName:
+			scheduledFeeds[entry] = nuget.Feed{}
+		case pypi.FeedName:
+			scheduledFeeds[entry] = pypi.Feed{}
+		case packagist.FeedName:
+			scheduledFeeds[entry] = packagist.Feed{}
+		case rubygems.FeedName:
+			scheduledFeeds[entry] = rubygems.Feed{}
+		default:
+			err = fmt.Errorf("unknown feed type %v", entry)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse enabled_feeds entries: %w", err)
+	}
+	return scheduledFeeds, nil
+}
+
+// Produces a Publisher object from the provided PublisherConfig
+// The PublisherConfig.Type value is evaluated and the appropriate Publisher is
+// constructed from the Config field.
+func (pc PublisherConfig) ToPublisher(ctx context.Context) (publisher.Publisher, error) {
+	var err error
+	switch pc.Type {
+	case gcppubsub.PublisherType:
+		var config gcppubsub.PubSubConfig
+		err = strictDecode(pc.Config, &config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode gcppubsub config: %w", err)
+		}
+		return gcppubsub.FromConfig(ctx, config)
+	case stdout.PublisherType:
+		return stdout.New(), nil
+	default:
+		err = fmt.Errorf("unknown publisher type %v", pc.Type)
+	}
+	return nil, err
+}
+
+// Decode an input using mapstruct decoder with strictness enabled, errors will be returned in
+// the case of unused fields.
+func strictDecode(input interface{}, out interface{}) error {
+	strictDecoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      out,
+	})
+	if err != nil {
+		return err
+	}
+	return strictDecoder.Decode(input)
+}
+
+func Default() *ScheduledFeedConfig {
+	config := &ScheduledFeedConfig{
+		EnabledFeeds: []string{
+			crates.FeedName,
+			goproxy.FeedName,
+			npm.FeedName,
+			nuget.FeedName,
+			packagist.FeedName,
+			pypi.FeedName,
+			rubygems.FeedName,
+		},
+		PubConfig: PublisherConfig{
+			Type: stdout.PublisherType,
+		},
+		HttpPort: 8080,
+	}
+	config.applyEnvVars()
+	return config
+}
+
+// Unmarshals configuration data from bytes into the provided interface, strictness is
+// enabled which returns an error in the case that an unknown field is provided.
+func unmarshalStrict(data []byte, out interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}

--- a/config/structs.go
+++ b/config/structs.go
@@ -1,0 +1,12 @@
+package config
+
+type ScheduledFeedConfig struct {
+	PubConfig    PublisherConfig `yaml:"publisher"`
+	EnabledFeeds []string        `yaml:"enabled_feeds"`
+	HttpPort     int             `yaml:"http_port,omitempty"`
+}
+
+type PublisherConfig struct {
+	Type   string      `mapstructure:"type"`
+	Config interface{} `mapstructure:"config"`
+}

--- a/feeds/scheduler/scheduler.go
+++ b/feeds/scheduler/scheduler.go
@@ -1,16 +1,9 @@
 package scheduler
 
 import (
+	"github.com/ossf/package-feeds/feeds"
 	"time"
 
-	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/feeds/crates"
-	"github.com/ossf/package-feeds/feeds/goproxy"
-	"github.com/ossf/package-feeds/feeds/npm"
-	"github.com/ossf/package-feeds/feeds/nuget"
-	"github.com/ossf/package-feeds/feeds/packagist"
-	"github.com/ossf/package-feeds/feeds/pypi"
-	"github.com/ossf/package-feeds/feeds/rubygems"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,21 +12,11 @@ type Scheduler struct {
 	registry map[string]feeds.ScheduledFeed
 }
 
-// New returns a new Scheduler with available feeds registered
-func New() *Scheduler {
-	registry := map[string]feeds.ScheduledFeed{
-		crates.FeedName:    crates.Feed{},
-		goproxy.FeedName:   goproxy.Feed{},
-		npm.FeedName:       npm.Feed{},
-		packagist.FeedName: packagist.Feed{},
-		pypi.FeedName:      pypi.Feed{},
-		rubygems.FeedName:  rubygems.Feed{},
-		nuget.FeedName:     nuget.Feed{},
+// New returns a new Scheduler with configured feeds registered
+func New(feeds map[string]feeds.ScheduledFeed) *Scheduler {
+	return &Scheduler{
+		registry: feeds,
 	}
-	s := &Scheduler{
-		registry: registry,
-	}
-	return s
 }
 
 type pollResult struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/ossf/package-feeds
 go 1.15
 
 require (
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/sirupsen/logrus v1.8.1
 	gocloud.dev v0.22.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/publisher/gcppubsub/gcppubsub.go
+++ b/publisher/gcppubsub/gcppubsub.go
@@ -1,4 +1,4 @@
-package publisher
+package gcppubsub
 
 import (
 	"context"
@@ -11,7 +11,7 @@ type PubSub struct {
 	topic *pubsub.Topic
 }
 
-func NewPubSub(ctx context.Context, url string) (*PubSub, error) {
+func New(ctx context.Context, url string) (*PubSub, error) {
 	topic, err := pubsub.OpenTopic(context.TODO(), url)
 	if err != nil {
 		return nil, err

--- a/publisher/gcppubsub/gcppubsub.go
+++ b/publisher/gcppubsub/gcppubsub.go
@@ -7,8 +7,16 @@ import (
 	_ "gocloud.dev/pubsub/gcppubsub"
 )
 
+const (
+	PublisherType = "gcp_pubsub"
+)
+
 type PubSub struct {
 	topic *pubsub.Topic
+}
+
+type PubSubConfig struct {
+	URL string `mapstructure:"url"`
 }
 
 func New(ctx context.Context, url string) (*PubSub, error) {
@@ -22,8 +30,12 @@ func New(ctx context.Context, url string) (*PubSub, error) {
 	return pub, nil
 }
 
+func FromConfig(ctx context.Context, config PubSubConfig) (*PubSub, error) {
+	return New(ctx, config.URL)
+}
+
 func (pub *PubSub) Name() string {
-	return "gcp-pubsub"
+	return PublisherType
 }
 
 func (pub *PubSub) Send(ctx context.Context, body []byte) error {

--- a/publisher/stdout/stdout.go
+++ b/publisher/stdout/stdout.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 )
 
+const (
+	PublisherType = "stdout"
+)
+
 type Stdout struct{}
 
 func New() *Stdout {
@@ -12,7 +16,7 @@ func New() *Stdout {
 }
 
 func (pub *Stdout) Name() string {
-	return "stdout"
+	return PublisherType
 }
 
 func (pub *Stdout) Send(ctx context.Context, body []byte) error {

--- a/publisher/stdout/stdout.go
+++ b/publisher/stdout/stdout.go
@@ -1,4 +1,4 @@
-package publisher
+package stdout
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 
 type Stdout struct{}
 
-func NewStdoutPublisher() *Stdout {
+func New() *Stdout {
 	return &Stdout{}
 }
 


### PR DESCRIPTION
Feeds and publishers have been slightly reworked to support
configuration in place of constant endpoints. In addition to this
it is now possible to support a limited subset of feeds and also multiple
feeds of the same type with different endpoints.

Default behaviour has been preserved through a combination of default configurations
and mutating configurations post-load based on environment variables.