### PR TITLE
Add test cases for the various feeds

### DIFF
--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -10,7 +10,13 @@ import (
 
 const (
 	FeedName = "crates"
-	url      = "https://crates.io/api/v1/summary"
+)
+
+var (
+	baseURL    = "https://crates.io/api/v1/summary"
+	httpClient = &http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 type crates struct {
@@ -29,10 +35,7 @@ type Package struct {
 
 // Gets crates.io packages
 func fetchPackages() ([]*Package, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Get(url)
+	resp, err := httpClient.Get(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +50,8 @@ func fetchPackages() ([]*Package, error) {
 	return v.JustUpdated, nil
 }
 
-type Feed struct{}
+type Feed struct {
+}
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}

--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -1,0 +1,112 @@
+package crates
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestCratesLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/api/v1/summary": cratesSummaryResponse,
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	baseURL = srv.URL + "/api/v1/summary"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+
+	if err != nil {
+		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+
+	if pkgs[0].Name != "FooPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `FooPackage`", pkgs[0].Name)
+	}
+	if pkgs[1].Name != "BarPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `BarPackage`", pkgs[1].Name)
+	}
+	if pkgs[0].Version != "0.2.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.2.0`", pkgs[0].Version)
+	}
+	if pkgs[1].Version != "0.1.1" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.1.1`", pkgs[1].Version)
+	}
+
+	for _, p := range pkgs {
+		if p.Type != FeedName {
+			t.Errorf("Feed type not set correctly in crates package following Latest()")
+		}
+	}
+}
+
+func cratesSummaryResponse(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`
+{
+	"just_updated": [
+		{
+			"id": "FooPackage",
+			"name": "FooPackage",
+			"updated_at": "2021-03-19T13:36:33.871721+00:00",
+			"versions": null,
+			"keywords": null,
+			"categories": null,
+			"badges": null,
+			"created_at": "2021-03-17T20:04:15.901201+00:00",
+			"downloads": 46,
+			"recent_downloads": 46,
+			"max_version": "0.2.0",
+			"newest_version": "0.2.0",
+			"max_stable_version": "0.2.0",
+			"description": "Package for foo mangement",
+			"homepage": "https://github.com/Foo/Foo",
+			"documentation": "https://github.com/Foo/Foo",
+			"repository": "https://github.com/Foo/Foo",
+			"links": {
+			"version_downloads": "/api/v1/crates/Foo/downloads",
+			"versions": "/api/v1/crates/Foo/versions",
+			"owners": "/api/v1/crates/Foo/owners",
+			"owner_team": "/api/v1/crates/Foo/owner_team",
+			"owner_user": "/api/v1/crates/Foo/owner_user",
+			"reverse_dependencies": "/api/v1/crates/Foo/reverse_dependencies"
+			},
+			"exact_match": false
+		},
+		{
+			"id": "BarPackage",
+			"name": "BarPackage",
+			"updated_at": "2021-03-19T13:17:25.784319+00:00",
+			"versions": null,
+			"keywords": null,
+			"categories": null,
+			"badges": null,
+			"created_at": "2021-03-13T14:24:30.835625+00:00",
+			"downloads": 31,
+			"recent_downloads": 31,
+			"max_version": "0.1.1",
+			"newest_version": "0.1.1",
+			"max_stable_version": "0.1.1",
+			"description": "Provides Bar functionality",
+			"homepage": "https://github.com/Bar/Bar",
+			"documentation": "https://github.com/Bar/Bar",
+			"repository": "https://github.com/Bar/Bar",
+			"links": {
+			"version_downloads": "/api/v1/crates/Bar/downloads",
+			"versions": "/api/v1/crates/Bar/versions",
+			"owners": "/api/v1/crates/Bar/owners",
+			"owner_team": "/api/v1/crates/Bar/owner_team",
+			"owner_user": "/api/v1/crates/Bar/owner_user",
+			"reverse_dependencies": "/api/v1/crates/Bar/reverse_dependencies"
+			},
+			"exact_match": false
+		}
+		]
+}
+`))
+}

--- a/feeds/goproxy/goproxy.go
+++ b/feeds/goproxy/goproxy.go
@@ -14,7 +14,11 @@ import (
 
 const (
 	FeedName = "goproxy"
-	baseURL  = "https://index.golang.org/index"
+)
+
+var (
+	baseURL    = "https://index.golang.org/index"
+	httpClient = &http.Client{Timeout: 10 * time.Second}
 )
 
 type PackageJSON struct {
@@ -31,11 +35,10 @@ type Package struct {
 
 func fetchPackages(since time.Time) ([]Package, error) {
 	var packages []Package
-	client := &http.Client{Timeout: 10 * time.Second}
 	params := url.Values{}
 	params.Add("since", since.Format(time.RFC3339))
 	requestURL := fmt.Sprintf("%s?%s", baseURL, params.Encode())
-	resp, err := client.Get(requestURL)
+	resp, err := httpClient.Get(requestURL)
 	if err != nil {
 		return nil, err
 	}

--- a/feeds/goproxy/goproxy_test.go
+++ b/feeds/goproxy/goproxy_test.go
@@ -1,0 +1,56 @@
+package goproxy
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestGoProxyLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/index": goproxyPackageResponse,
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	baseURL = srv.URL + "/index"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+
+	if pkgs[0].Name != "golang.org/x/foo" {
+		t.Errorf("Unexpected package `%s` found in place of expected `golang.org/x/foo`", pkgs[0].Name)
+	}
+	if pkgs[1].Name != "golang.org/x/bar" {
+		t.Errorf("Unexpected package `%s` found in place of expected `golang.org/x/bar`", pkgs[1].Name)
+	}
+	if pkgs[0].Version != "v0.3.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `v0.3.0`", pkgs[0].Version)
+	}
+	if pkgs[1].Version != "v0.4.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `v0.4.0`", pkgs[1].Version)
+	}
+
+	for _, p := range pkgs {
+		if p.Type != FeedName {
+			t.Errorf("Feed type not set correctly in goproxy package following Latest()")
+		}
+	}
+}
+
+func goproxyPackageResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`{"Path": "golang.org/x/foo","Version": "v0.3.0","Timestamp": "2019-04-10T19:08:52.997264Z"}
+{"Path": "golang.org/x/bar","Version": "v0.4.0","Timestamp": "2019-04-10T20:30:02.04035Z"}
+`))
+	if err != nil {
+		fmt.Println("Unexpected error during mock http server write: %w", err)
+	}
+}

--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -11,9 +11,15 @@ import (
 )
 
 const (
-	FeedName   = "npm"
+	FeedName = "npm"
+)
+
+var (
 	baseURL    = "https://registry.npmjs.org/-/rss"
 	versionURL = "https://registry.npmjs.org/"
+	httpClient = &http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 type Response struct {
@@ -55,10 +61,7 @@ func (t *rfc1123Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 }
 
 func fetchPackages() ([]*Package, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Get(baseURL)
+	resp, err := httpClient.Get(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +76,7 @@ func fetchPackages() ([]*Package, error) {
 
 // Gets the package version from the NPM.
 func fetchVersionInformation(packageName string) (string, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Get(fmt.Sprintf("%s/%s", versionURL, packageName))
+	resp, err := httpClient.Get(fmt.Sprintf("%s/%s", versionURL, packageName))
 	if err != nil {
 		return "", err
 	}

--- a/feeds/npm/npm_test.go
+++ b/feeds/npm/npm_test.go
@@ -1,0 +1,103 @@
+package npm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestNpmLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/-/rss/":     npmLatestPackagesResponse,
+		"/FooPackage": fooVersionInfoResponse,
+		"/BarPackage": barVersionInfoResponse,
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	baseURL = srv.URL + "/-/rss/"
+	versionURL = srv.URL + "/"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+
+	if pkgs[0].Name != "FooPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `FooPackage`", pkgs[0].Name)
+	}
+	if pkgs[1].Name != "BarPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `BarPackage`", pkgs[1].Name)
+	}
+	if pkgs[0].Version != "1.0.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `1.0.0`", pkgs[0].Version)
+	}
+	if pkgs[1].Version != "0.4.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.4.0`", pkgs[1].Version)
+	}
+
+	for _, p := range pkgs {
+		if p.Type != FeedName {
+			t.Errorf("Feed type not set correctly in npm package following Latest()")
+		}
+	}
+}
+
+func npmLatestPackagesResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`
+<?xml version="1.0" encoding="UTF-8"?><rss>
+    <channel>
+        <title><![CDATA[npm recent updates]]></title>
+        <lastBuildDate>Mon, 22 Mar 2021 13:45:33 GMT</lastBuildDate>
+        <pubDate>Mon, 22 Mar 2021 13:45:33 GMT</pubDate>
+        <item>
+            <title><![CDATA[FooPackage]]></title>
+            <dc:creator><![CDATA[FooMan]]></dc:creator>
+            <pubDate>Mon, 22 Mar 2021 13:07:29 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[BarPackage]]></title>
+            <dc:creator><![CDATA[BarMan]]></dc:creator>
+            <pubDate>Mon, 22 Mar 2021 13:45:16 GMT</pubDate>
+        </item>
+    </channel>
+</rss>
+`))
+	if err != nil {
+		fmt.Println("Unexpected error during mock http server write: %w", err)
+	}
+}
+
+func fooVersionInfoResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`
+{
+	"name": "FooPackage",
+	"dist-tags": {
+		"latest": "1.0.0"
+	}
+}
+`))
+	if err != nil {
+		fmt.Println("Unexpected error during mock http server write: %w", err)
+	}
+}
+
+func barVersionInfoResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`
+{
+	"name": "BarPackage",
+	"dist-tags": {
+		"latest": "0.4.0"
+	}
+}
+`))
+	if err != nil {
+		fmt.Println("Unexpected error during mock http server write: %w", err)
+	}
+}

--- a/feeds/pypi/pypi.go
+++ b/feeds/pypi/pypi.go
@@ -11,7 +11,13 @@ import (
 
 const (
 	FeedName = "pypi"
-	baseURL  = "https://pypi.org/rss/updates.xml"
+)
+
+var (
+	baseURL    = "https://pypi.org/rss/updates.xml"
+	httpClient = &http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 type Response struct {
@@ -53,10 +59,7 @@ func (t *rfc1123Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 }
 
 func fetchPackages() ([]*Package, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Get(baseURL)
+	resp, err := httpClient.Get(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +72,8 @@ func fetchPackages() ([]*Package, error) {
 	return rssResponse.Packages, nil
 }
 
-type Feed struct{}
+type Feed struct {
+}
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}

--- a/feeds/pypi/pypi_test.go
+++ b/feeds/pypi/pypi_test.go
@@ -1,0 +1,74 @@
+package pypi
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestPypiLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/rss/updates.xml": updatesXmlHandle,
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	baseURL = srv.URL + "/rss/updates.xml"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+
+	if pkgs[0].Name != "FooPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `FooPackage`", pkgs[0].Name)
+	}
+	if pkgs[1].Name != "BarPackage" {
+		t.Errorf("Unexpected package `%s` found in place of expected `BarPackage`", pkgs[1].Name)
+	}
+	if pkgs[0].Version != "0.0.2" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.0.2`", pkgs[0].Version)
+	}
+	if pkgs[1].Version != "0.7a2" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.7a2`", pkgs[1].Version)
+	}
+
+	for _, p := range pkgs {
+		if p.Type != FeedName {
+			t.Errorf("Feed type not set correctly in pypi package following Latest()")
+		}
+	}
+}
+
+func updatesXmlHandle(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+	<channel>
+	<title>PyPI recent updates</title>
+	<link>https://pypi.org/</link>
+	<description>Recent updates to the Python Package Index</description>
+	<language>en</language>
+	<item>
+		<title>FooPackage 0.0.2</title>
+		<link>https://pypi.org/project/FooPackage/0.0.2/</link>
+		<description>Python wrapper for fooing</description>
+		<author>fooman@bazco.org</author>
+		<pubDate>Fri, 19 Mar 2021 12:01:04 GMT</pubDate>
+	</item>
+	<item>
+		<title>BarPackage 0.7a2</title>
+		<link>https://pypi.org/project/BarPackage/0.7a2/</link>
+		<description>A package full of bars</description>
+		<author>barman@bazco.org</author>
+		<pubDate>Fri, 19 Mar 2021 12:00:39 GMT</pubDate>
+	</item>
+	</channel>
+</rss>
+`))
+}

--- a/feeds/rubygems/rubygems.go
+++ b/feeds/rubygems/rubygems.go
@@ -11,7 +11,13 @@ import (
 
 const (
 	FeedName = "rubygems"
-	baseURL  = "https://rubygems.org/api/v1/activity"
+)
+
+var (
+	baseURL    = "https://rubygems.org/api/v1/activity"
+	httpClient = &http.Client{
+		Timeout: 10 * time.Second,
+	}
 )
 
 type Package struct {
@@ -21,10 +27,7 @@ type Package struct {
 }
 
 func fetchPackages(url string) ([]*Package, error) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +37,8 @@ func fetchPackages(url string) ([]*Package, error) {
 	return response, err
 }
 
-type Feed struct{}
+type Feed struct {
+}
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}

--- a/feeds/rubygems/rubygems_test.go
+++ b/feeds/rubygems/rubygems_test.go
@@ -1,0 +1,122 @@
+package rubygems
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestRubyLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/api/v1/activity/latest.json":       rubyGemsPackagesResponse,
+		"/api/v1/activity/just_updated.json": rubyGemsPackagesResponse,
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	baseURL = srv.URL + "/api/v1/activity"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+
+	if err != nil {
+		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+
+	var fooPkg *feeds.Package
+	var barPkg *feeds.Package
+
+	// rubygems constructs pkgs from a dict so the order is unpredictable
+	for _, pkg := range pkgs {
+		switch pkg.Name {
+		case "FooPackage":
+			fooPkg = pkg
+		case "BarPackage":
+			barPkg = pkg
+		default:
+			t.Errorf("Unexpected package `%s` found in packages", pkg.Name)
+		}
+	}
+
+	if fooPkg == nil || barPkg == nil {
+		t.Errorf("Expected package not found from rubygems Feed.Latest()")
+	}
+
+	if fooPkg.Version != "0.13.0" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.13.0`", pkgs[0].Version)
+	}
+	if barPkg.Version != "0.0.3" {
+		t.Errorf("Unexpected version `%s` found in place of expected `0.0.3`", pkgs[1].Version)
+	}
+
+	for _, p := range pkgs {
+		if p.Type != FeedName {
+			t.Errorf("Feed type not set correctly in ruby package following Latest()")
+		}
+	}
+}
+
+func rubyGemsPackagesResponse(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`
+[
+	{
+		"name": "FooPackage",
+		"downloads": 35,
+		"version": "0.13.0",
+		"version_created_at": "2021-03-19T13:00:43.260Z",
+		"version_downloads": 35,
+		"platform": "ruby",
+		"authors": "FooMan",
+		"info": "A package to support Foo",
+		"licenses": [
+			"MIT"
+		],
+		"metadata": {},
+		"yanked": false,
+		"sha": "8649253fb98b8ed0f733e2fc723b2435ead35cb1a70004ebff821abe7abaf131",
+		"project_uri": "https://rubygems.org/gems/FooPackage",
+		"gem_uri": "https://rubygems.org/gems/FooPackage-0.13.0.gem",
+		"homepage_uri": "http://github.com/FooMan/FooPackage/",
+		"wiki_uri": null,
+		"documentation_uri": "https://www.rubydoc.info/gems/FooPackage/0.13.0",
+		"mailing_list_uri": null,
+		"source_code_uri": null,
+		"bug_tracker_uri": null,
+		"changelog_uri": null,
+		"funding_uri": null
+	},
+	{
+		"name": "BarPackage",
+		"downloads": 41,
+		"version": "0.0.3",
+		"version_created_at": "2021-03-19T12:52:15.157Z",
+		"version_downloads": 41,
+		"platform": "ruby",
+		"authors": "BarMan",
+		"info": "A package to add Bar support.",
+		"licenses": [
+			"MIT"
+		],
+		"metadata": {},
+		"yanked": false,
+		"sha": "fd38fbd77499eb494fd84e710034314287d6895460253aec4a7d105e3199a0fb",
+		"project_uri": "https://rubygems.org/gems/BarPackage",
+		"gem_uri": "https://rubygems.org/gems/BarPackage-0.0.3.gem",
+		"homepage_uri": "http://github.com/BarMan/BarPackage/",
+		"wiki_uri": null,
+		"documentation_uri": "https://www.rubydoc.info/gems/BarPackage/0.0.3",
+		"mailing_list_uri": null,
+		"source_code_uri": null,
+		"bug_tracker_uri": null,
+		"changelog_uri": null,
+		"funding_uri": null
+	}
+]
+
+`))
+}

--- a/testutils/http_helper.go
+++ b/testutils/http_helper.go
@@ -1,0 +1,18 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+type HttpHandlerFunc func(w http.ResponseWriter, r *http.Request)
+
+func HttpServerMock(handlerFuncs map[string]HttpHandlerFunc) *httptest.Server {
+	handler := http.NewServeMux()
+	for endpoint, f := range handlerFuncs {
+		handler.HandleFunc(endpoint, f)
+	}
+	srv := httptest.NewServer(handler)
+
+	return srv
+}


### PR DESCRIPTION
This PR aims to add tests for all of the feeds currently implemented. These tests should be easily extended to be more exhaustive.

- [x] crates
- [x] rubygems
- [x] goproxy
- [x] npm  
- [x] pypi