### PR TITLE
WIP: Add pypi_critical feed

### DIFF
--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/ossf/package-feeds/config"
 	"github.com/ossf/package-feeds/feeds/scheduler"
@@ -80,7 +80,11 @@ func main() {
 	log.Infof("using %q publisher", pub.Name())
 
 	feeds, err := appConfig.GetScheduledFeeds()
-	log.Infof("watching feeds: %v", strings.Join(appConfig.EnabledFeeds, ", "))
+	feedNames := []string{}
+	for k, _ := range feeds {
+		feedNames = append(feedNames, k)
+	}
+	log.Infof("watching feeds: %v", strings.Join(feedNames, ", "))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config/structs.go
+++ b/config/structs.go
@@ -1,12 +1,13 @@
 package config
 
 type ScheduledFeedConfig struct {
-	PubConfig    PublisherConfig `yaml:"publisher"`
-	EnabledFeeds []string        `yaml:"enabled_feeds"`
-	HttpPort     int             `yaml:"http_port,omitempty"`
+	PubConfig    TypeConfigPair   `yaml:"publisher"`
+	EnabledFeeds []string         `yaml:"enabled_feeds"`
+	Feeds        []TypeConfigPair `yaml:"feeds"`
+	HttpPort     int              `yaml:"http_port,omitempty"`
 }
 
-type PublisherConfig struct {
+type TypeConfigPair struct {
 	Type   string      `mapstructure:"type"`
 	Config interface{} `mapstructure:"config"`
 }

--- a/feeds/pypi_critical/pypi.go
+++ b/feeds/pypi_critical/pypi.go
@@ -1,0 +1,140 @@
+package pypi_critical
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+)
+
+const (
+	FeedName = "pypi_critical"
+)
+
+var (
+	packageUrlFormat = "https://pypi.org/rss/project/%s/releases.xml"
+	httpClient       = &http.Client{
+		Timeout: 10 * time.Second,
+	}
+)
+
+type Response struct {
+	Packages []*Package `xml:"channel>item"`
+	pkgName  string
+}
+
+type Package struct {
+	Title       string      `xml:"title"`
+	CreatedDate rfc1123Time `xml:"pubDate"`
+	Link        string      `xml:"link"`
+}
+
+func (p *Package) Name() (string, error) {
+	// The XML Link ends with /packageName/Version/
+	parts := strings.Split(p.Link, "/")
+	if len(parts) < 5 {
+		return "", fmt.Errorf("invalid link provided by pypi releases API")
+	}
+	return parts[len(parts)-3], nil
+}
+
+func (p *Package) Version() string {
+	// The XML Feed has a "Title" element that contains the release version.
+	return p.Title
+}
+
+type rfc1123Time struct {
+	time.Time
+}
+
+func (t *rfc1123Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var marshaledTime string
+	err := d.DecodeElement(&marshaledTime, &start)
+	if err != nil {
+		return err
+	}
+	decodedTime, err := time.Parse(time.RFC1123, marshaledTime)
+	if err != nil {
+		return err
+	}
+	*t = rfc1123Time{decodedTime}
+	return nil
+}
+
+func fetchPackages(packageList []string) ([]*Package, error) {
+	responseChannel := make(chan *Response)
+	errs := make(chan error)
+	var wg sync.WaitGroup
+
+	for _, pkgName := range packageList {
+		wg.Add(1)
+		go func(pkgName string) {
+			resp, err := httpClient.Get(fmt.Sprintf(packageUrlFormat, pkgName))
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer resp.Body.Close()
+			rssResponse := &Response{}
+			err = xml.NewDecoder(resp.Body).Decode(rssResponse)
+			if err != nil {
+				errs <- err
+				return
+			}
+			wg.Done()
+			responseChannel <- rssResponse
+		}(pkgName)
+	}
+	wg.Wait()
+	select {
+	case err := <-errs:
+		return nil, err
+	default:
+		close(errs)
+	}
+
+	pkgs := []*Package{}
+	for i := 0; i < len(packageList); i++ {
+		select {
+		case response := <-responseChannel:
+			for _, pkg := range response.Packages {
+				pkgs = append(pkgs, pkg)
+			}
+		default:
+			return nil, fmt.Errorf("unexpected missing package release response")
+		}
+	}
+	return pkgs, nil
+}
+
+type Feed struct {
+	PackageList []string `mapstructure:"packages"`
+}
+
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+	pkgs := []*feeds.Package{}
+	pypiPackages, err := fetchPackages(feed.PackageList)
+	if err != nil {
+		return pkgs, err
+	}
+	for _, pkg := range pypiPackages {
+		if pkg.CreatedDate.Before(cutoff) {
+			continue
+		}
+		pkgName, err := pkg.Name()
+		if err != nil {
+			return nil, err
+		}
+		pkgs = append(pkgs, &feeds.Package{
+			Name:        pkgName,
+			Version:     pkg.Version(),
+			CreatedDate: pkg.CreatedDate.Time,
+			Type:        FeedName,
+		})
+	}
+	return pkgs, nil
+}

--- a/feeds/pypi_critical/pypi_test.go
+++ b/feeds/pypi_critical/pypi_test.go
@@ -1,0 +1,106 @@
+package pypi_critical
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/testutils"
+)
+
+func TestPypiCriticalLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HttpHandlerFunc{
+		"/rss/project/foopy/releases.xml": foopyReleasesResponse,
+		"/rss/project/barpy/releases.xml": barpyReleasesResponse,
+	}
+	packageList = []string{
+		"foopy",
+		"barpy",
+	}
+	srv := testutils.HttpServerMock(handlers)
+
+	packageUrlFormat = srv.URL + "/rss/project/%s/releases.xml"
+	feed := Feed{}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("failed to call Latest() with err: %v", err)
+	}
+
+	const expectedNumPackages = 4
+	if len(pkgs) != expectedNumPackages {
+		t.Fatalf("Latest() produced %v packages instead of the expected %v", len(pkgs), expectedNumPackages)
+	}
+	pkgMap := map[string]map[string]*feeds.Package{}
+	pkgMap["foopy"] = map[string]*feeds.Package{}
+	pkgMap["barpy"] = map[string]*feeds.Package{}
+
+	for _, pkg := range pkgs {
+		pkgMap[pkg.Name][pkg.Version] = pkg
+	}
+
+	if _, ok := pkgMap["foopy"]["2.1"]; !ok {
+		t.Fatalf("missing foopy 2.1")
+	}
+	if _, ok := pkgMap["foopy"]["2.0"]; !ok {
+		t.Fatalf("missing foopy 2.0")
+	}
+	if _, ok := pkgMap["barpy"]["1.1"]; !ok {
+		t.Fatalf("missing barpy 1.1")
+	}
+	if _, ok := pkgMap["barpy"]["1.0"]; !ok {
+		t.Fatalf("missing barpy 1.0")
+	}
+}
+
+func foopyReleasesResponse(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`
+	<?xml version="1.0" encoding="UTF-8"?>
+	<rss version="2.0">
+	  <channel>
+		<title>PyPI recent updates for foopy</title>
+		<link>https://pypi.org/project/foopy/</link>
+		<description>Recent updates to the Python Package Index for foopy</description>
+		<language>en</language>
+		<item>
+		  <title>2.1</title>
+		  <link>https://pypi.org/project/foopy/2.1/</link>
+		  <pubDate>Sat, 27 Mar 2021 22:16:26 GMT</pubDate>
+		</item>
+		<item>
+		  <title>2.0</title>
+		  <link>https://pypi.org/project/foopy/2.0/</link>
+		  <pubDate>Sun, 23 Sep 2018 16:50:37 GMT</pubDate>
+		</item>
+	  </channel>
+	</rss>
+`))
+}
+
+func barpyReleasesResponse(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte(`
+	<?xml version="1.0" encoding="UTF-8"?>
+	<rss version="2.0">
+	  <channel>
+		<title>PyPI recent updates for barpy</title>
+		<link>https://pypi.org/project/barpy/</link>
+		<description>Recent updates to the Python Package Index for barpy</description>
+		<language>en</language>
+		<item>
+		  <title>1.1</title>
+		  <link>https://pypi.org/project/barpy/1.1/</link>
+		  <pubDate>Sat, 27 Mar 2021 22:16:26 GMT</pubDate>
+		</item>
+		<item>
+		  <title>1.0</title>
+		  <link>https://pypi.org/project/barpy/1.0/</link>
+		  <pubDate>Sun, 23 Sep 2018 16:50:37 GMT</pubDate>
+		</item>
+	  </channel>
+	</rss>
+`))
+}


### PR DESCRIPTION
This implementation is subject to change and serves as an illustration of one way we could approach the problem detailed in #83. Adding this to a new feed is a simple way of handling this for one use case (pypi) but if the problem exists in many feeds it may be better to adapt the `ScheduledFeed` interface to provide some functionality to query APIs for specific 'critical' packages where loss of updates is simply not an option.