### PR TITLE
Add basic cron based 'timer' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ publisher:
 http_port: 8080
 
 cutoff_delta: 5m
+
+timer: false
 ```
 
-`cutoff_delta` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration). To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+`cutoff_delta` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).
+`timer` will configure interal polling of the `enabled_feeds` at the given `cutoff_delta` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
 
 ## Legacy Configuration
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ publisher:
 
 http_port: 8080
 cutoff_delta: 5m
+timer: true
 `
 	TestConfigStrUnknownFeedType = `
 enabled_feeds:

--- a/config/scheduledfeed.go
+++ b/config/scheduledfeed.go
@@ -162,6 +162,7 @@ func Default() *ScheduledFeedConfig {
 		},
 		HttpPort:    8080,
 		CutoffDelta: "5m",
+		Timer:       false,
 	}
 	config.applyEnvVars()
 	return config

--- a/config/structs.go
+++ b/config/structs.go
@@ -5,6 +5,7 @@ type ScheduledFeedConfig struct {
 	EnabledFeeds []string        `yaml:"enabled_feeds"`
 	HttpPort     int             `yaml:"http_port,omitempty"`
 	CutoffDelta  string          `yaml:"cutoff_delta"`
+	Timer        bool            `yaml:"timer"`
 }
 
 type PublisherConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/mitchellh/mapstructure v1.4.1
+	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	gocloud.dev v0.22.0
 	gocloud.dev/pubsub/kafkapubsub v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCb
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=


### PR DESCRIPTION
This leverages the `cutoff_delta` config, adding the option to set an internal `cron` like scheduler for triggering the polling of feeds. The current implementation somewhat mimics the current trigger which is driven by requests from an external scheduled [service](https://github.com/ossf/package-feeds/blob/main/terraform/scheduler/main.tf). 

As mentioned in #85 this is one approach that uses a static frequency, this could be expanded to be dynamic (storing an internal value for `time_of_last_poll`, to use for the `cuttoff` threshold instead potentially on a per feed basis). Further to that is the consideration of if a httpserver should even be launched in this `standalone` mode, or even a hybrid approach. These can all be considered in followup PRs
