### PR TITLE
Add event framework (Log Lossy Feed events)

### DIFF
--- a/config/scheduledfeed.go
+++ b/config/scheduledfeed.go
@@ -88,22 +88,26 @@ func AddTo(ls *[]int, value int) {
 func (config *ScheduledFeedConfig) GetScheduledFeeds() (map[string]feeds.ScheduledFeed, error) {
 	var err error
 	scheduledFeeds := map[string]feeds.ScheduledFeed{}
+	eventHandler, err := config.GetEventHandler()
+	if err != nil {
+		return nil, err
+	}
 	for _, entry := range config.EnabledFeeds {
 		switch entry {
 		case crates.FeedName:
-			scheduledFeeds[entry] = crates.Feed{}
+			scheduledFeeds[entry] = crates.New(eventHandler)
 		case goproxy.FeedName:
 			scheduledFeeds[entry] = goproxy.Feed{}
 		case npm.FeedName:
-			scheduledFeeds[entry] = npm.Feed{}
+			scheduledFeeds[entry] = npm.New(eventHandler)
 		case nuget.FeedName:
 			scheduledFeeds[entry] = nuget.Feed{}
 		case pypi.FeedName:
-			scheduledFeeds[entry] = pypi.Feed{}
+			scheduledFeeds[entry] = pypi.New(eventHandler)
 		case packagist.FeedName:
 			scheduledFeeds[entry] = packagist.Feed{}
 		case rubygems.FeedName:
-			scheduledFeeds[entry] = rubygems.Feed{}
+			scheduledFeeds[entry] = rubygems.New(eventHandler)
 		default:
 			err = fmt.Errorf("%w : %v", errUnknownFeed, entry)
 		}

--- a/config/structs.go
+++ b/config/structs.go
@@ -1,14 +1,30 @@
 package config
 
+import "github.com/ossf/package-feeds/events"
+
 type ScheduledFeedConfig struct {
-	PubConfig    PublisherConfig `yaml:"publisher"`
-	EnabledFeeds []string        `yaml:"enabled_feeds"`
-	HTTPPort     int             `yaml:"http_port,omitempty"`
-	PollRate     string          `yaml:"poll_rate"`
-	Timer        bool            `yaml:"timer"`
+	// Configures the publisher for pushing packages after polling
+	PubConfig PublisherConfig `yaml:"publisher"`
+
+	// Configures the feeds to be used for polling from package repositories
+	EnabledFeeds []string `yaml:"enabled_feeds"`
+
+	HTTPPort int    `yaml:"http_port,omitempty"`
+	PollRate string `yaml:"poll_rate"`
+	Timer    bool   `yaml:"timer"`
+
+	// Configures the EventHandler instance to be used throughout the package-feeds application
+	EventsConfig *EventsConfig `yaml:"events"`
+
+	eventHandler *events.Handler
 }
 
 type PublisherConfig struct {
 	Type   string      `mapstructure:"type"`
 	Config interface{} `mapstructure:"config"`
+}
+
+type EventsConfig struct {
+	Sink        string        `yaml:"sink"`
+	EventFilter events.Filter `yaml:"filter"`
 }

--- a/events/handler.go
+++ b/events/handler.go
@@ -1,0 +1,115 @@
+package events
+
+const (
+	// Event Types.
+	LossyFeedEventType = "LOSSY_FEED"
+
+	// Components.
+	FeedsComponentType = "Feeds"
+)
+
+type Sink interface {
+	AddEvent(e Event) error
+}
+
+type Event interface {
+	GetComponent() string
+	GetType() string
+	GetMessage() string
+}
+
+type Filter struct {
+	EnabledEventTypes  []string `yaml:"enabled_event_types"`
+	DisabledEventTypes []string `yaml:"disabled_event_types"`
+
+	EnabledComponents []string `yaml:"enabled_components"`
+}
+
+type Handler struct {
+	eventSink   Sink
+	eventFilter Filter
+}
+
+func NewHandler(sink Sink, filter Filter) *Handler {
+	return &Handler{
+		eventSink:   sink,
+		eventFilter: filter,
+	}
+}
+
+func NewNullHandler() *Handler {
+	return &Handler{}
+}
+
+// Creates a filter for use with an event handler, nil can be provided for non values.
+func NewFilter(enabledEventTypes, disabledEventTypes, enabledComponents []string) *Filter {
+	if enabledEventTypes == nil {
+		enabledEventTypes = []string{}
+	}
+	if disabledEventTypes == nil {
+		disabledEventTypes = []string{}
+	}
+	if enabledComponents == nil {
+		enabledComponents = []string{}
+	}
+	return &Filter{
+		EnabledEventTypes:  enabledEventTypes,
+		DisabledEventTypes: disabledEventTypes,
+		EnabledComponents:  enabledComponents,
+	}
+}
+
+// Dispatches an event to the configured sink if it passes the configured filter.
+func (h *Handler) DispatchEvent(e Event) error {
+	if h.eventSink == nil {
+		return nil
+	}
+	filter := h.eventFilter
+
+	if filter.ShouldDispatch(e) {
+		return h.eventSink.AddEvent(e)
+	}
+	return nil
+}
+
+func (h *Handler) GetSink() Sink {
+	return h.eventSink
+}
+
+func (h *Handler) GetFilter() Filter {
+	return h.eventFilter
+}
+
+// Checks whether an event should be dispatched under the configured
+// filter options.
+// Options are applied as follows:
+// 	- disabled event types are always disabled.
+//  - enabled event types are enabled
+//  - enabled components are enabled except for disabled event types.
+func (f Filter) ShouldDispatch(e Event) bool {
+	dispatch := false
+	eComponent := e.GetComponent()
+	eType := e.GetType()
+
+	// Enable components.
+	if stringExistsInSlice(eComponent, f.EnabledComponents) {
+		dispatch = true
+	}
+	// Handle specific event types.
+	if stringExistsInSlice(eType, f.EnabledEventTypes) {
+		dispatch = true
+	} else if stringExistsInSlice(eType, f.DisabledEventTypes) {
+		dispatch = false
+	}
+	return dispatch
+}
+
+// Checks for existence of a string within a slice of strings.
+func stringExistsInSlice(s string, slice []string) bool {
+	for _, sliceStr := range slice {
+		if s == sliceStr {
+			return true
+		}
+	}
+	return false
+}

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -1,0 +1,93 @@
+package events
+
+import (
+	"testing"
+)
+
+func TestHandlerDispatchEventNoFilterConfigured(t *testing.T) {
+	t.Parallel()
+
+	sink := &MockSink{}
+	filter := NewFilter(nil, nil, nil)
+
+	handler := NewHandler(sink, *filter)
+
+	event := &LossyFeedEvent{
+		Feed: "Foo",
+	}
+
+	err := handler.DispatchEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sink.events) != 0 {
+		t.Error("LossyFeedEvent was dispatched despite not being enabled")
+	}
+}
+
+func TestHandlerDispatchEventFilterAllowLossyFeed(t *testing.T) {
+	t.Parallel()
+
+	sink := &MockSink{}
+	filter := NewFilter([]string{LossyFeedEventType}, nil, nil)
+
+	handler := NewHandler(sink, *filter)
+
+	event := &LossyFeedEvent{
+		Feed: "Foo",
+	}
+
+	err := handler.DispatchEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sink.events) != 1 {
+		t.Error("LossyFeedEvent was not dispatched despite being configured to allow dispatch")
+	}
+}
+
+func TestHandlerDispatchEventFilterAllowFeedComponent(t *testing.T) {
+	t.Parallel()
+
+	sink := &MockSink{}
+	filter := NewFilter(nil, nil, []string{FeedsComponentType})
+
+	handler := NewHandler(sink, *filter)
+
+	event := &LossyFeedEvent{
+		Feed: "Foo",
+	}
+
+	err := handler.DispatchEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sink.events) != 1 {
+		t.Error("LossyFeedEvent was not dispatched despite feeds component being allowed")
+	}
+}
+
+func TestHandlerDispatchEventFilterDisableLossyFeed(t *testing.T) {
+	t.Parallel()
+
+	sink := &MockSink{}
+	filter := NewFilter(nil, []string{LossyFeedEventType}, []string{FeedsComponentType})
+
+	handler := NewHandler(sink, *filter)
+
+	event := &LossyFeedEvent{
+		Feed: "Foo",
+	}
+
+	err := handler.DispatchEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sink.events) != 0 {
+		t.Error("LossyFeedEvent was dispatched despite being configured to disable dispatch")
+	}
+}

--- a/events/logrus_sink.go
+++ b/events/logrus_sink.go
@@ -1,0 +1,30 @@
+package events
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	LoggingEventSinkType = "stdout"
+)
+
+type LoggingEventSink struct {
+	logger *logrus.Logger
+}
+
+// Creates an event sink which logs events using a provided logrus logger,
+// fields "component" and "event_type" are applied to the logger and
+// warnings are logged for each event.
+func NewLoggingEventSink(logger *logrus.Logger) *LoggingEventSink {
+	return &LoggingEventSink{
+		logger: logger,
+	}
+}
+
+func (sink LoggingEventSink) AddEvent(e Event) error {
+	sink.logger.WithFields(logrus.Fields{
+		"event_type": e.GetType(),
+		"component":  e.GetComponent(),
+	}).Warn(e.GetMessage())
+	return nil
+}

--- a/events/logrus_sink_test.go
+++ b/events/logrus_sink_test.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestLogrusSink(t *testing.T) {
+	t.Parallel()
+
+	log, hook := test.NewNullLogger()
+
+	sink := NewLoggingEventSink(log)
+
+	event := LossyFeedEvent{
+		Feed: "Foo",
+	}
+
+	err := sink.AddEvent(event)
+	if err != nil {
+		t.Error(err)
+	}
+
+	logEntry := hook.LastEntry()
+	if logEntry == nil {
+		t.Fatal("Log entry was not added to the configured logger")
+	}
+
+	if logEntry.Data["event_type"] != event.GetType() {
+		t.Errorf(
+			"Log entry had incorrect event_type field '%v' when '%v' was expected",
+			logEntry.Data["event_type"],
+			event.GetType(),
+		)
+	}
+
+	if logEntry.Data["component"] != event.GetComponent() {
+		t.Errorf(
+			"Log entry had incorrect component field '%v' when '%v' was expected",
+			logEntry.Data["component"],
+			event.GetComponent(),
+		)
+	}
+}

--- a/events/lossy_feed_event.go
+++ b/events/lossy_feed_event.go
@@ -1,0 +1,21 @@
+package events
+
+import (
+	"fmt"
+)
+
+type LossyFeedEvent struct {
+	Feed string
+}
+
+func (e LossyFeedEvent) GetComponent() string {
+	return FeedsComponentType
+}
+
+func (e LossyFeedEvent) GetType() string {
+	return LossyFeedEventType
+}
+
+func (e LossyFeedEvent) GetMessage() string {
+	return fmt.Sprintf("detected potential missing package data when polling %v feed", e.Feed)
+}

--- a/events/mocks.go
+++ b/events/mocks.go
@@ -1,0 +1,32 @@
+package events
+
+type MockSink struct {
+	events []Event
+}
+
+func (s *MockSink) GetEvents() []Event {
+	return s.events
+}
+
+func (s *MockSink) AddEvent(e Event) error {
+	s.events = append(s.events, e)
+	return nil
+}
+
+type MockEvent struct {
+	Component string
+	Type      string
+	Message   string
+}
+
+func (e MockEvent) GetComponent() string {
+	return e.Component
+}
+
+func (e MockEvent) GetType() string {
+	return e.Type
+}
+
+func (e MockEvent) GetMessage() string {
+	return e.Message
+}

--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -59,11 +59,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 		return pkgs, err
 	}
 	for _, pkg := range packages {
-		pkg, err := feeds.NewPackage(pkg.UpdatedAt, cutoff, pkg.Name, pkg.NewestVersion, FeedName)
-		if err != nil {
-			continue
-		}
+		pkg := feeds.NewPackage(pkg.UpdatedAt, pkg.Name, pkg.NewestVersion, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 	return pkgs, nil
 }

--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -17,7 +18,7 @@ func TestCratesLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/api/v1/summary"
-	feed := Feed{}
+	feed := New(events.NewNullHandler())
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/goproxy/goproxy.go
+++ b/feeds/goproxy/goproxy.go
@@ -77,11 +77,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 		return pkgs, fmt.Errorf("error fetching packages: %w", err)
 	}
 	for _, pkg := range packages {
-		pkg, err := feeds.NewPackage(pkg.ModifiedDate, cutoff, pkg.Title, pkg.Version, FeedName)
-		if err != nil {
-			continue
-		}
+		pkg := feeds.NewPackage(pkg.ModifiedDate, pkg.Title, pkg.Version, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 	return pkgs, nil
 }

--- a/feeds/lossy_logging.go
+++ b/feeds/lossy_logging.go
@@ -1,0 +1,65 @@
+package feeds
+
+import (
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/ossf/package-feeds/events"
+)
+
+type LossyFeedAlerter struct {
+	previousPackages map[string][]*Package
+	eventHandler     *events.Handler
+}
+
+// Creates a LossyFeedAlerter, capable of tracking packages and identifying
+// potential loss in feeds using RSS style APIs. This can only be used in
+// feeds which produce an overlap of packages upon their requests to the API,
+// if a timestamp is used to query the API then loss is unlikely due to requesting
+// data since a previous query.
+func NewLossyFeedAlerter(eventHandler *events.Handler) *LossyFeedAlerter {
+	return &LossyFeedAlerter{
+		eventHandler:     eventHandler,
+		previousPackages: map[string][]*Package{},
+	}
+}
+
+// Processes a new collection of packages and compares against the previously processed
+// slice of packages, if an overlap is not detected this is a sign of potential loss of
+// data and the configured event handler is notified via a LossyFeedEvent.
+func (lfa *LossyFeedAlerter) ProcessPackages(feed string, packages []*Package) {
+	pkgs := make([]*Package, len(packages))
+	copy(pkgs, packages)
+
+	// Ensure packages are sorted by CreatedDate in order of most recent
+	sort.SliceStable(pkgs, func(i, j int) bool {
+		return pkgs[j].CreatedDate.Before(pkgs[i].CreatedDate)
+	})
+
+	previousPackages, ok := lfa.previousPackages[feed]
+	nonZeroResults := len(pkgs) > 0 && len(previousPackages) > 0
+	if ok && nonZeroResults {
+		if !findOverlap(pkgs, previousPackages) {
+			err := lfa.eventHandler.DispatchEvent(events.LossyFeedEvent{
+				Feed: feed,
+			})
+			if err != nil {
+				log.WithError(err).Error("failed to dispatch event via event handler")
+			}
+		}
+	}
+	lfa.previousPackages[feed] = pkgs
+}
+
+// Checks whether there is an overlap in package creation date between a result
+// and a previous result. This assumes that pollResult.packages is sorted by
+// CreatedDate in order of most recent first.
+func findOverlap(latestPackages, previousPackages []*Package) bool {
+	rOldestPkg := latestPackages[len(latestPackages)-1]
+	previousResultMostRecent := previousPackages[0]
+
+	afterDate := previousResultMostRecent.CreatedDate.After(rOldestPkg.CreatedDate)
+	equalDate := previousResultMostRecent.CreatedDate.Equal(rOldestPkg.CreatedDate)
+	return afterDate || equalDate
+}

--- a/feeds/lossy_logging_test.go
+++ b/feeds/lossy_logging_test.go
@@ -41,3 +41,35 @@ func TestProcessPackagesNoOverlap(t *testing.T) {
 		t.Errorf("ProcessPackages did not produce a lossy feed event")
 	}
 }
+
+func TestProcessPackagesWithOverlap(t *testing.T) {
+	t.Parallel()
+	feedName := "foo-feed"
+
+	mockSink := &events.MockSink{}
+	allowLossyFeedEventsFilter := events.NewFilter([]string{events.LossyFeedEventType}, nil, nil)
+	eventHandler := events.NewHandler(mockSink, *allowLossyFeedEventsFilter)
+	lossyFeedAlerter := NewLossyFeedAlerter(eventHandler)
+
+	baseTime := time.Date(2021, 4, 20, 14, 30, 0, 0, time.UTC)
+	pkgs1 := []*Package{
+		NewPackage(baseTime.Add(-time.Minute*2), "foopkg", "1.0", feedName),
+		NewPackage(baseTime.Add(-time.Minute*3), "barpkg", "1.0", feedName),
+	}
+	// Populate previous packages
+	lossyFeedAlerter.ProcessPackages(feedName, pkgs1)
+
+	pkgs2 := []*Package{
+		NewPackage(baseTime, "bazpkg", "1.0", feedName),
+		NewPackage(baseTime.Add(-time.Minute*1), "quxpkg", "2.0", feedName),
+		NewPackage(baseTime.Add(-time.Minute*2), "foopkg", "1.0", feedName),
+	}
+	// Trigger overlap
+	lossyFeedAlerter.ProcessPackages(feedName, pkgs2)
+
+	evs := mockSink.GetEvents()
+
+	if len(evs) != 0 {
+		t.Fatalf("ProcessPackages failed to identify an overlap when one existed")
+	}
+}

--- a/feeds/lossy_logging_test.go
+++ b/feeds/lossy_logging_test.go
@@ -1,0 +1,43 @@
+package feeds
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/events"
+)
+
+func TestProcessPackagesNoOverlap(t *testing.T) {
+	t.Parallel()
+	feedName := "foo-feed"
+
+	mockSink := &events.MockSink{}
+	allowLossyFeedEventsFilter := events.NewFilter([]string{events.LossyFeedEventType}, nil, nil)
+	eventHandler := events.NewHandler(mockSink, *allowLossyFeedEventsFilter)
+	lossyFeedAlerter := NewLossyFeedAlerter(eventHandler)
+
+	baseTime := time.Date(2021, 4, 20, 14, 30, 0, 0, time.UTC)
+	pkgs1 := []*Package{
+		NewPackage(baseTime.Add(-time.Minute*2), "foopkg", "1.0", feedName),
+		NewPackage(baseTime.Add(-time.Minute*3), "barpkg", "1.0", feedName),
+	}
+	// Populate previous packages
+	lossyFeedAlerter.ProcessPackages(feedName, pkgs1)
+
+	pkgs2 := []*Package{
+		NewPackage(baseTime, "bazpkg", "1.0", feedName),
+		NewPackage(baseTime.Add(-time.Minute*1), "quxpkg", "2.0", feedName),
+	}
+	// Trigger no overlap
+	lossyFeedAlerter.ProcessPackages(feedName, pkgs2)
+
+	evs := mockSink.GetEvents()
+
+	if len(evs) != 1 {
+		t.Fatalf("ProcessPackages failed to detect a lack of overlap")
+	}
+
+	if evs[0].GetType() != events.LossyFeedEventType {
+		t.Errorf("ProcessPackages did not produce a lossy feed event")
+	}
+}

--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -102,11 +102,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 		if err != nil {
 			return pkgs, fmt.Errorf("error in fetching version information: %w", err)
 		}
-		pkg, err := feeds.NewPackage(pkg.CreatedDate.Time, cutoff, pkg.Title, v, FeedName)
-		if err != nil {
-			continue
-		}
+		pkg := feeds.NewPackage(pkg.CreatedDate.Time, pkg.Title, v, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 	return pkgs, nil
 }

--- a/feeds/npm/npm_test.go
+++ b/feeds/npm/npm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -21,7 +22,7 @@ func TestNpmLatest(t *testing.T) {
 
 	baseURL = srv.URL + "/-/rss/"
 	versionURL = srv.URL + "/"
-	feed := Feed{}
+	feed := New(events.NewNullHandler())
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -171,13 +171,14 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 				return nil, err
 			}
 
-			pkg, err := feeds.NewPackage(pkgInfo.Created, cutoff, pkgInfo.PackageID, pkgInfo.Version, FeedName)
+			pkg := feeds.NewPackage(pkgInfo.Created, pkgInfo.PackageID, pkgInfo.Version, FeedName)
 			if err != nil {
 				continue
 			}
 			pkgs = append(pkgs, pkg)
 		}
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 
 	return pkgs, nil
 }

--- a/feeds/pypi/pypi.go
+++ b/feeds/pypi/pypi.go
@@ -81,11 +81,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 		return pkgs, err
 	}
 	for _, pkg := range pypiPackages {
-		pkg, err := feeds.NewPackage(pkg.CreatedDate.Time, cutoff, pkg.Name(), pkg.Version(), FeedName)
-		if err != nil {
-			continue
-		}
+		pkg := feeds.NewPackage(pkg.CreatedDate.Time, pkg.Name(), pkg.Version(), FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 	return pkgs, nil
 }

--- a/feeds/pypi/pypi_test.go
+++ b/feeds/pypi/pypi_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -17,7 +18,7 @@ func TestPypiLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/rss/updates.xml"
-	feed := Feed{}
+	feed := New(events.NewNullHandler())
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/rubygems/rubygems.go
+++ b/feeds/rubygems/rubygems.go
@@ -58,11 +58,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	}
 
 	for _, pkg := range packages {
-		pkg, err := feeds.NewPackage(pkg.CreatedDate, cutoff, pkg.Name, pkg.Version, FeedName)
-		if err != nil {
-			continue
-		}
+		pkg := feeds.NewPackage(pkg.CreatedDate, pkg.Name, pkg.Version, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
 	return pkgs, nil
 }

--- a/feeds/rubygems/rubygems_test.go
+++ b/feeds/rubygems/rubygems_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
@@ -19,7 +20,7 @@ func TestRubyLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/api/v1/activity"
-	feed := Feed{}
+	feed := New(events.NewNullHandler())
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/scheduler/scheduler.go
+++ b/feeds/scheduler/scheduler.go
@@ -44,11 +44,19 @@ func (s *Scheduler) Poll(cutoff time.Time) ([]*feeds.Package, []error) {
 	packages := []*feeds.Package{}
 	for i := 0; i < len(s.registry); i++ {
 		result := <-results
+
 		logger := log.WithField("feed", result.name)
 		if result.err != nil {
 			logger.WithError(result.err).Error("error fetching packages")
 			errs = append(errs, result.err)
 			continue
+		}
+		for _, pkg := range result.packages {
+			log.WithFields(log.Fields{
+				"feed":    result.name,
+				"name":    pkg.Name,
+				"version": pkg.Version,
+			}).Print("Processing Package")
 		}
 		packages = append(packages, result.packages...)
 		logger.WithField("num_processed", len(result.packages)).Print("processed packages")


### PR DESCRIPTION
This PR introduces an event framework for driving defined system events
through a sink interface. A logrus logging sink is implemented
initially for logging event locally but event could also be
dispatched to alternative metrics/logging mechanisms.

The initial event which is added for this is to log and
identify potential loss of data between polling intervals.
This lossy feed problem is detailed in issue #83 and whilst
this doesn't fix the problem, it can help to identify and monitor
occurrences of this issue within a long running production environment.

Lossy feed event checking and dispatch is added as a utility in the feeds package 
and is implemented within the currently supported feeds which have the potential to be lossy 
(crates, npm, pypi, rubygems).
