### PR TITLE
Use lastPoll time as cutoff on subsequent polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ publisher:
 
 http_port: 8080
 
-cutoff_delta: 5m
+poll_rate: 5m
 
 timer: false
 ```
 
-`cutoff_delta` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).
-`timer` will configure interal polling of the `enabled_feeds` at the given `cutoff_delta` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+`poll_rate` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).This is used as an initial value to generate a cutoff point for feed events relative to the given time at execution, with subsequent events using the previous time at execution as the cutoff point.
+`timer` will configure interal polling of the `enabled_feeds` at the given `poll_rate` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
 
 ## Legacy Configuration
 
 Legacy configuration methods are still supported. By default, without a configuration file all feeds will be enabled. The environment variable `OSSMALWARE_TOPIC_URL` can be used to select the GCP pubsub publisher and `PORT` will configure the port for the HTTP server.
-The default `cutoff_delta` is 5 minutes, this is used to generate a cutoff point for feed events relative to the given time at execution.
+The default `poll_rate` is 5 minutes, it is assumed that an external service is dispatching requests to the configured HTTP server at this frequency.
+
 
 # Contributing
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ publisher:
     endpoint: "https://foobaz.com"
 
 http_port: 8080
-cutoff_delta: 5m
+poll_rate: 5m
 timer: true
 `
 	TestConfigStrUnknownFeedType = `

--- a/config/scheduledfeed.go
+++ b/config/scheduledfeed.go
@@ -167,9 +167,9 @@ func Default() *ScheduledFeedConfig {
 		PubConfig: PublisherConfig{
 			Type: stdout.PublisherType,
 		},
-		HTTPPort:    8080,
-		CutoffDelta: "5m",
-		Timer:       false,
+		HTTPPort: 8080,
+		PollRate: "5m",
+		Timer:    false,
 	}
 	config.applyEnvVars()
 	return config

--- a/config/structs.go
+++ b/config/structs.go
@@ -4,7 +4,7 @@ type ScheduledFeedConfig struct {
 	PubConfig    PublisherConfig `yaml:"publisher"`
 	EnabledFeeds []string        `yaml:"enabled_feeds"`
 	HTTPPort     int             `yaml:"http_port,omitempty"`
-	CutoffDelta  string          `yaml:"cutoff_delta"`
+	PollRate     string          `yaml:"poll_rate"`
 	Timer        bool            `yaml:"timer"`
 }
 


### PR DESCRIPTION
This is additional work towards #85 

Using the last poll time as a cutoff marker on subsequent polls should help with robustness against missed events, for instance if a previously scheduled poll event was missed or delayed. In reverse an unscheduled poll event could be triggered in an interval, losing the assumed synchronisation of the static cutoff mechanism.  If the configuration surface is extended to allow variable polling rates (per feed, for example) then this could simply be extended to a `map`, or similar.