### PR TITLE
Add support for optional package lists for feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ behavior data for anyone interested.
 A YAML configuration file can be provided with the following format:
 
 ```
-enabled_feeds:
-- pypi
-- npm
-- goproxy
-- rubygems
-- crates
+feeds:
+- type: pypi
+- type: npm
+- type: goproxy
+- type: rubygems
+- type: crates
 
 publisher:
   type: 'gcp_pubsub'
@@ -47,7 +47,21 @@ timer: false
 ```
 
 `poll_rate` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).This is used as an initial value to generate a cutoff point for feed events relative to the given time at execution, with subsequent events using the previous time at execution as the cutoff point.
-`timer` will configure interal polling of the `enabled_feeds` at the given `poll_rate` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+`timer` will configure interal polling of the `feeds` at the given `poll_rate` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+
+## FeedOptions
+
+Feeds can be configured with additional options, not all feeds will support these features. See the appropriate feed `README.md` for supported options.
+Below is an example of such options with pypi being configured to poll a specific set of packages
+
+```
+feeds:
+- type: pypi
+  options:
+    packages:
+    - fooPackage
+    - barPackage
+```
 
 ## Legacy Configuration
 

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -113,7 +113,11 @@ func main() {
 	log.Infof("using %q publisher", pub.Name())
 
 	scheduledFeeds, err := appConfig.GetScheduledFeeds()
-	log.Infof("watching feeds: %v", strings.Join(appConfig.EnabledFeeds, ", "))
+	feedNames := []string{}
+	for k := range scheduledFeeds {
+		feedNames = append(feedNames, k)
+	}
+	log.Infof("watching feeds: %v", strings.Join(feedNames, ", "))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config/structs.go
+++ b/config/structs.go
@@ -1,19 +1,22 @@
 package config
 
-import "github.com/ossf/package-feeds/events"
+import (
+	"github.com/ossf/package-feeds/events"
+	"github.com/ossf/package-feeds/feeds"
+)
 
 type ScheduledFeedConfig struct {
-	// Configures the publisher for pushing packages after polling
+	// Configures the publisher for pushing packages after polling.
 	PubConfig PublisherConfig `yaml:"publisher"`
 
-	// Configures the feeds to be used for polling from package repositories
-	EnabledFeeds []string `yaml:"enabled_feeds"`
+	// Configures the feeds to be used for polling from package repositories.
+	Feeds []FeedConfig `yaml:"feeds"`
 
 	HTTPPort int    `yaml:"http_port,omitempty"`
 	PollRate string `yaml:"poll_rate"`
 	Timer    bool   `yaml:"timer"`
 
-	// Configures the EventHandler instance to be used throughout the package-feeds application
+	// Configures the EventHandler instance to be used throughout the package-feeds application.
 	EventsConfig *EventsConfig `yaml:"events"`
 
 	eventHandler *events.Handler
@@ -22,6 +25,11 @@ type ScheduledFeedConfig struct {
 type PublisherConfig struct {
 	Type   string      `mapstructure:"type"`
 	Config interface{} `mapstructure:"config"`
+}
+
+type FeedConfig struct {
+	Type    string            `mapstructure:"type"`
+	Options feeds.FeedOptions `mapstructure:"options"`
 }
 
 type EventsConfig struct {

--- a/feeds/crates/README.md
+++ b/feeds/crates/README.md
@@ -1,0 +1,13 @@
+# Crates Feed
+
+This feed allows polling of package updates from the crates package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the crates feed.
+
+
+```
+feeds:
+- type: crates
+```

--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -55,10 +55,16 @@ type Feed struct {
 	lossyFeedAlerter *feeds.LossyFeedAlerter
 }
 
-func New(eventHandler *events.Handler) *Feed {
+func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
 	return &Feed{
 		lossyFeedAlerter: feeds.NewLossyFeedAlerter(eventHandler),
-	}
+	}, nil
 }
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {

--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/events"
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -18,7 +19,10 @@ func TestCratesLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/api/v1/summary"
-	feed := New(events.NewNullHandler())
+	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	if err != nil {
+		t.Fatalf("failed to create crates feed: %v", err)
+	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -1,13 +1,26 @@
 package feeds
 
 import (
+	"fmt"
 	"time"
 )
 
 const schemaVer = "1.0"
 
+type UnsupportedOptionError struct {
+	Option string
+	Feed   string
+}
+
 type ScheduledFeed interface {
 	Latest(cutoff time.Time) ([]*Package, error)
+}
+
+// General configuration options for feeds.
+type FeedOptions struct {
+	// A collection of package names to poll instead of standard firehose behaviour.
+	// Not supported by all feeds.
+	Packages *[]string `yaml:"packages"`
 }
 
 // Marshalled json output validated against package.schema.json.
@@ -37,4 +50,8 @@ func ApplyCutoff(pkgs []*Package, cutoff time.Time) []*Package {
 		}
 	}
 	return filteredPackages
+}
+
+func (err UnsupportedOptionError) Error() string {
+	return fmt.Sprintf("unsupported option `%v` supplied to %v feed", err.Option, err.Feed)
 }

--- a/feeds/goproxy/README.md
+++ b/feeds/goproxy/README.md
@@ -1,0 +1,13 @@
+# goproxy Feed
+
+This feed allows polling of package updates from the golang.org/index package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the goproxy feed.
+
+
+```
+feeds:
+- type: goproxy
+```

--- a/feeds/goproxy/goproxy.go
+++ b/feeds/goproxy/goproxy.go
@@ -70,6 +70,16 @@ func fetchPackages(since time.Time) ([]Package, error) {
 
 type Feed struct{}
 
+func New(feedOptions feeds.FeedOptions) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
+	return &Feed{}, nil
+}
+
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}
 	packages, err := fetchPackages(cutoff)

--- a/feeds/npm/README.md
+++ b/feeds/npm/README.md
@@ -1,0 +1,13 @@
+# npm Feed
+
+This feed allows polling of package updates from the repository.npmjs.org package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the npm feed.
+
+
+```
+feeds:
+- type: npm
+```

--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -94,10 +94,16 @@ type Feed struct {
 	lossyFeedAlerter *feeds.LossyFeedAlerter
 }
 
-func New(eventHandler *events.Handler) *Feed {
+func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
 	return &Feed{
 		lossyFeedAlerter: feeds.NewLossyFeedAlerter(eventHandler),
-	}
+	}, nil
 }
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {

--- a/feeds/npm/npm_test.go
+++ b/feeds/npm/npm_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/events"
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -22,7 +23,10 @@ func TestNpmLatest(t *testing.T) {
 
 	baseURL = srv.URL + "/-/rss/"
 	versionURL = srv.URL + "/"
-	feed := New(events.NewNullHandler())
+	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	if err != nil {
+		t.Fatalf("failed to create new npm feed: %v", err)
+	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/nuget/README.md
+++ b/feeds/nuget/README.md
@@ -1,0 +1,13 @@
+# nuget Feed
+
+This feed allows polling of package updates from the nuget package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the nuget feed.
+
+
+```
+feeds:
+- type: nuget
+```

--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -131,6 +131,16 @@ func fetchPackageInfo(url string) (*nugetPackageDetails, error) {
 
 type Feed struct{}
 
+func New(feedOptions feeds.FeedOptions) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
+	return &Feed{}, nil
+}
+
 // Latest will parse all creation events for packages in the nuget.org catalog feed
 // for packages that have been published since the cutoff
 // https://docs.microsoft.com/en-us/nuget/api/catalog-resource

--- a/feeds/packagist/README.md
+++ b/feeds/packagist/README.md
@@ -1,0 +1,13 @@
+# packagist Feed
+
+This feed allows polling of package updates from the packagist package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the packagist feed.
+
+
+```
+feeds:
+- type: packagist
+```

--- a/feeds/packagist/packagist.go
+++ b/feeds/packagist/packagist.go
@@ -30,6 +30,16 @@ type actions struct {
 
 type Feed struct{}
 
+func New(feedOptions feeds.FeedOptions) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
+	return &Feed{}, nil
+}
+
 func fetchPackages(since time.Time) ([]actions, error) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,

--- a/feeds/pypi/README.md
+++ b/feeds/pypi/README.md
@@ -1,0 +1,18 @@
+# Pypi Feed
+
+This feed allows polling of package updates from the pypi package repository.
+
+## Configuration options
+
+The `packages` Field can be supplied to the pypi feed options to enable polling of package specific apis. This is less effective
+with large lists of packages as it polls the RSS feed for each package individually but it is much less likely to miss package updates between polling.
+
+
+```
+feeds:
+- type: pypi
+  options:
+    packages:
+    - numpy
+    - scipy
+```

--- a/feeds/pypi/pypi_test.go
+++ b/feeds/pypi/pypi_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/events"
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -18,7 +19,10 @@ func TestPypiLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/rss/updates.xml"
-	feed := New(events.NewNullHandler())
+	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	if err != nil {
+		t.Fatalf("failed to create new pypi feed: %v", err)
+	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)
@@ -46,6 +50,60 @@ func TestPypiLatest(t *testing.T) {
 	}
 }
 
+func TestPypiCriticalLatest(t *testing.T) {
+	t.Parallel()
+
+	handlers := map[string]testutils.HTTPHandlerFunc{
+		"/rss/project/foopy/releases.xml": foopyReleasesResponse,
+		"/rss/project/barpy/releases.xml": barpyReleasesResponse,
+	}
+	packages := []string{
+		"foopy",
+		"barpy",
+	}
+	srv := testutils.HTTPServerMock(handlers)
+
+	packageURLFormat = srv.URL + "/rss/project/%s/releases.xml"
+	feed, err := New(feeds.FeedOptions{
+		Packages: &packages,
+	}, events.NewNullHandler())
+	if err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	}
+
+	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	pkgs, err := feed.Latest(cutoff)
+	if err != nil {
+		t.Fatalf("failed to call Latest() with err: %v", err)
+	}
+
+	const expectedNumPackages = 4
+	if len(pkgs) != expectedNumPackages {
+		t.Fatalf("Latest() produced %v packages instead of the expected %v", len(pkgs), expectedNumPackages)
+	}
+	pkgMap := map[string]map[string]*feeds.Package{}
+	pkgMap["foopy"] = map[string]*feeds.Package{}
+	pkgMap["barpy"] = map[string]*feeds.Package{}
+
+	for _, pkg := range pkgs {
+		pkgMap[pkg.Name][pkg.Version] = pkg
+	}
+
+	if _, ok := pkgMap["foopy"]["2.1"]; !ok {
+		t.Fatalf("missing foopy 2.1")
+	}
+	if _, ok := pkgMap["foopy"]["2.0"]; !ok {
+		t.Fatalf("missing foopy 2.0")
+	}
+	if _, ok := pkgMap["barpy"]["1.1"]; !ok {
+		t.Fatalf("missing barpy 1.1")
+	}
+	if _, ok := pkgMap["barpy"]["1.0"]; !ok {
+		t.Fatalf("missing barpy 1.0")
+	}
+}
+
+// Mock data for pypi firehose with all packages.
 func updatesXMLHandle(w http.ResponseWriter, r *http.Request) {
 	_, err := w.Write([]byte(`
 <?xml version="1.0" encoding="UTF-8"?>
@@ -71,6 +129,64 @@ func updatesXMLHandle(w http.ResponseWriter, r *http.Request) {
 	</item>
 	</channel>
 </rss>
+`))
+	if err != nil {
+		http.Error(w, testutils.UnexpectedWriteError(err), http.StatusInternalServerError)
+	}
+}
+
+// Mock data response for package specific api when pypi is configured with
+// a package list in FeedOptions.
+func foopyReleasesResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`
+	<?xml version="1.0" encoding="UTF-8"?>
+	<rss version="2.0">
+	  <channel>
+		<title>PyPI recent updates for foopy</title>
+		<link>https://pypi.org/project/foopy/</link>
+		<description>Recent updates to the Python Package Index for foopy</description>
+		<language>en</language>
+		<item>
+		  <title>2.1</title>
+		  <link>https://pypi.org/project/foopy/2.1/</link>
+		  <pubDate>Sat, 27 Mar 2021 22:16:26 GMT</pubDate>
+		</item>
+		<item>
+		  <title>2.0</title>
+		  <link>https://pypi.org/project/foopy/2.0/</link>
+		  <pubDate>Sun, 23 Sep 2018 16:50:37 GMT</pubDate>
+		</item>
+	  </channel>
+	</rss>
+`))
+	if err != nil {
+		http.Error(w, testutils.UnexpectedWriteError(err), http.StatusInternalServerError)
+	}
+}
+
+// Mock data response for package specific api when pypi is configured with
+// a package list in FeedOptions.
+func barpyReleasesResponse(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte(`
+	<?xml version="1.0" encoding="UTF-8"?>
+	<rss version="2.0">
+	  <channel>
+		<title>PyPI recent updates for barpy</title>
+		<link>https://pypi.org/project/barpy/</link>
+		<description>Recent updates to the Python Package Index for barpy</description>
+		<language>en</language>
+		<item>
+		  <title>1.1</title>
+		  <link>https://pypi.org/project/barpy/1.1/</link>
+		  <pubDate>Sat, 27 Mar 2021 22:16:26 GMT</pubDate>
+		</item>
+		<item>
+		  <title>1.0</title>
+		  <link>https://pypi.org/project/barpy/1.0/</link>
+		  <pubDate>Sun, 23 Sep 2018 16:50:37 GMT</pubDate>
+		</item>
+	  </channel>
+	</rss>
 `))
 	if err != nil {
 		http.Error(w, testutils.UnexpectedWriteError(err), http.StatusInternalServerError)

--- a/feeds/rubygems/README.md
+++ b/feeds/rubygems/README.md
@@ -1,0 +1,13 @@
+# rubygems Feed
+
+This feed allows polling of package updates from the rubygems package repository.
+
+## Configuration options
+
+The `packages` field is not supported by the rubygems feed.
+
+
+```
+feeds:
+- type: rubygems
+```

--- a/feeds/rubygems/rubygems.go
+++ b/feeds/rubygems/rubygems.go
@@ -42,10 +42,16 @@ type Feed struct {
 	lossyFeedAlerter *feeds.LossyFeedAlerter
 }
 
-func New(eventHandler *events.Handler) *Feed {
+func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, error) {
+	if feedOptions.Packages != nil {
+		return nil, feeds.UnsupportedOptionError{
+			Feed:   FeedName,
+			Option: "packages",
+		}
+	}
 	return &Feed{
 		lossyFeedAlerter: feeds.NewLossyFeedAlerter(eventHandler),
-	}
+	}, nil
 }
 
 func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {

--- a/feeds/rubygems/rubygems_test.go
+++ b/feeds/rubygems/rubygems_test.go
@@ -20,7 +20,10 @@ func TestRubyLatest(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	baseURL = srv.URL + "/api/v1/activity"
-	feed := New(events.NewNullHandler())
+	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	if err != nil {
+		t.Fatalf("failed to create new ruby feed: %v", err)
+	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)


### PR DESCRIPTION
This PR allows feeds to be configured with a set of packages to poll. In the case of certain feeds, this can help avoid [lossy behaviour](https://github.com/ossf/package-feeds/issues/83) by ensuring the latest updates from those specific packages are checked during polling.

Support for this option is currently implemented in pypi and an error is reported when attempting to configure other feeds with this unsupported option.

Partially resolves https://github.com/ossf/package-feeds/issues/83