### PR TITLE
Utilise goroutines when polling for npm package versions

### DIFF
--- a/feeds/npm/npm_test.go
+++ b/feeds/npm/npm_test.go
@@ -64,12 +64,12 @@ func npmLatestPackagesResponse(w http.ResponseWriter, r *http.Request) {
         <item>
             <title><![CDATA[FooPackage]]></title>
             <dc:creator><![CDATA[FooMan]]></dc:creator>
-            <pubDate>Mon, 22 Mar 2021 13:07:29 GMT</pubDate>
+            <pubDate>Mon, 22 Mar 2021 13:45:16 GMT</pubDate>
         </item>
         <item>
             <title><![CDATA[BarPackage]]></title>
             <dc:creator><![CDATA[BarMan]]></dc:creator>
-            <pubDate>Mon, 22 Mar 2021 13:45:16 GMT</pubDate>
+            <pubDate>Mon, 22 Mar 2021 13:07:29 GMT</pubDate>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Resolves https://github.com/ossf/package-feeds/issues/102

With `npm` as the only configured feed, some rudimentary results when executed side-by-side with **main** on the same host.

**main-bc1e1e9**
```
time curl http://localhost:8080
49 packages processed
real	0m6.562s
user	0m0.010s
sys	0m0.005s

```
**tom--pollard:npm_goroutine**
```
time curl http://localhost:8081
49 packages processed
real	0m1.410s
user	0m0.011s
sys	0m0.000s
```