### PR TITLE
Ignore non-utf8 in XML decoding

### DIFF
--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 func TestCratesLatest(t *testing.T) {

--- a/feeds/goproxy/goproxy_test.go
+++ b/feeds/goproxy/goproxy_test.go
@@ -1,13 +1,12 @@
 package goproxy
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 func TestGoProxyLatest(t *testing.T) {
@@ -55,6 +54,6 @@ func goproxyPackageResponse(w http.ResponseWriter, r *http.Request) {
 {"Path": "golang.org/x/bar","Version": "v0.4.0","Timestamp": "2019-04-10T20:30:02.04035Z"}
 `))
 	if err != nil {
-		fmt.Println("Unexpected error during mock http server write: %w", err)
+		http.Error(w, testutils.UnexpectedWriteError(err), http.StatusInternalServerError)
 	}
 }

--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -66,7 +67,8 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	}
 	defer resp.Body.Close()
 	rssResponse := &Response{}
-	err = xml.NewDecoder(resp.Body).Decode(rssResponse)
+	reader := utils.NewUTF8OnlyReader(resp.Body)
+	err = xml.NewDecoder(reader).Decode(rssResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/feeds/nuget/nuget_test.go
+++ b/feeds/nuget/nuget_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 var testEndpoint *url.URL

--- a/feeds/packagist/packagist_test.go
+++ b/feeds/packagist/packagist_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 func TestFetch(t *testing.T) {

--- a/feeds/pypi/pypi.go
+++ b/feeds/pypi/pypi.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -78,7 +79,8 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	}
 	defer resp.Body.Close()
 	rssResponse := &Response{}
-	err = xml.NewDecoder(resp.Body).Decode(rssResponse)
+	reader := utils.NewUTF8OnlyReader(resp.Body)
+	err = xml.NewDecoder(reader).Decode(rssResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,8 @@ func fetchCriticalPackages(baseURL string, packageList []string) ([]*Package, er
 			}
 			defer resp.Body.Close()
 			rssResponse := &Response{}
-			err = xml.NewDecoder(resp.Body).Decode(rssResponse)
+			reader := utils.NewUTF8OnlyReader(resp.Body)
+			err = xml.NewDecoder(reader).Decode(rssResponse)
 			if err != nil {
 				errChannel <- err
 				return

--- a/feeds/pypi/pypi_test.go
+++ b/feeds/pypi/pypi_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 func TestPypiLatest(t *testing.T) {

--- a/feeds/rubygems/rubygems_test.go
+++ b/feeds/rubygems/rubygems_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
-	"github.com/ossf/package-feeds/testutils"
+	testutils "github.com/ossf/package-feeds/utils/test"
 )
 
 func TestRubyLatest(t *testing.T) {

--- a/utils/test/http_helper.go
+++ b/utils/test/http_helper.go
@@ -1,0 +1,23 @@
+package testutils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+type HTTPHandlerFunc func(w http.ResponseWriter, r *http.Request)
+
+func HTTPServerMock(handlerFuncs map[string]HTTPHandlerFunc) *httptest.Server {
+	handler := http.NewServeMux()
+	for endpoint, f := range handlerFuncs {
+		handler.HandleFunc(endpoint, f)
+	}
+	srv := httptest.NewServer(handler)
+
+	return srv
+}
+
+func UnexpectedWriteError(err error) string {
+	return fmt.Sprintf("Unexpected error during mock http server write: %s", err.Error())
+}

--- a/utils/utf8_decoder.go
+++ b/utils/utf8_decoder.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"bufio"
+	"io"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ValidUTF8Reader implements a Reader which ignores non utf-8 characters.
+type UTF8OnlyReader struct {
+	buffer *bufio.Reader
+}
+
+// NewValidUTF8Reader wraps a new UTF8OnlyReader around an existing reader.
+func NewUTF8OnlyReader(rd io.Reader) UTF8OnlyReader {
+	return UTF8OnlyReader{bufio.NewReader(rd)}
+}
+
+// Reads bytes into the byte array b whilst ignoring non utf-8 characters
+// Returns the number of bytes read and an error if one occurs.
+func (reader UTF8OnlyReader) Read(b []byte) (int, error) {
+	var numBytesRead int
+	for {
+		r, runeSize, err := reader.buffer.ReadRune()
+		if err != nil {
+			return numBytesRead, err
+		}
+
+		// Ignore non utf-8 characters
+		if r == unicode.ReplacementChar {
+			continue
+		}
+
+		// Finish Read if we don't have enough space for this rune in the output byte slice
+		if len(b)-numBytesRead <= runeSize {
+			err = reader.buffer.UnreadRune()
+			return numBytesRead, err
+		}
+
+		utf8.EncodeRune(b[numBytesRead:], r)
+		numBytesRead += runeSize
+	}
+}


### PR DESCRIPTION
Resolves #112 

Strips UTF-8 replacement characters from readers provided to XML decoders throughout feeds.