### PR TITLE
Utilise Feed structs for URL definitions

### DIFF
--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -14,14 +14,14 @@ func TestCratesLatest(t *testing.T) {
 	t.Parallel()
 
 	handlers := map[string]testutils.HTTPHandlerFunc{
-		"/api/v1/summary": cratesSummaryResponse,
+		activityPath: cratesSummaryResponse,
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	baseURL = srv.URL + "/api/v1/summary"
 	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	feed.baseURL = srv.URL
 	if err != nil {
-		t.Fatalf("failed to create crates feed: %v", err)
+		t.Fatalf("Failed to create crates feed: %v", err)
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/feeds/goproxy/goproxy_test.go
+++ b/feeds/goproxy/goproxy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -13,12 +14,15 @@ func TestGoProxyLatest(t *testing.T) {
 	t.Parallel()
 
 	handlers := map[string]testutils.HTTPHandlerFunc{
-		"/index": goproxyPackageResponse,
+		indexPath: goproxyPackageResponse,
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	baseURL = srv.URL + "/index"
-	feed := Feed{}
+	feed, err := New(feeds.FeedOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create goproxy feed: %v", err)
+	}
+	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)

--- a/feeds/npm/npm_test.go
+++ b/feeds/npm/npm_test.go
@@ -21,11 +21,11 @@ func TestNpmLatest(t *testing.T) {
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	baseURL = srv.URL + "/-/rss/"
-	versionURL = srv.URL + "/"
 	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	feed.baseURL = srv.URL
+
 	if err != nil {
-		t.Fatalf("failed to create new npm feed: %v", err)
+		t.Fatalf("Failed to create new npm feed: %v", err)
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/feeds/nuget/nuget_test.go
+++ b/feeds/nuget/nuget_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -16,7 +17,7 @@ func TestCanParseFeed(t *testing.T) {
 	t.Parallel()
 	var err error
 	handlers := map[string]testutils.HTTPHandlerFunc{
-		"/v3/index.json":          indexMock,
+		indexPath:                 indexMock,
 		"/v3/catalog0/index.json": catalogMock,
 		"/v3/catalog0/page1.json": catalogPageMock,
 		"/v3/catalog0/data/somecatalog/new.expected.package.0.0.1.json": packageDetailMock,
@@ -26,12 +27,16 @@ func TestCanParseFeed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error during test url parsing: %v", err)
 	}
-	feedURL, err = makeTestURL("v3/index.json")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sut := Feed{}
+	sut, err := New(feeds.FeedOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create nuget feed: %v", err)
+	}
+	sut.baseURL = srv.URL
+
 	cutoff := time.Now().Add(-5 * time.Minute)
 
 	results, err := sut.Latest(cutoff)

--- a/feeds/packagist/packagist_test.go
+++ b/feeds/packagist/packagist_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ossf/package-feeds/feeds"
 	"github.com/ossf/package-feeds/testutils"
 )
 
@@ -18,9 +19,13 @@ func TestFetch(t *testing.T) {
 	srv := testutils.HTTPServerMock(handlers)
 
 	defer srv.Close()
-	updateHost = srv.URL
-	versionHost = srv.URL
-	feed := Feed{}
+	feed, err := New(feeds.FeedOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create packagist feed: %v", err)
+	}
+	feed.updateHost = srv.URL
+	feed.versionHost = srv.URL
+
 	cutoff := time.Unix(1614513658, 0)
 	latest, err := feed.Latest(cutoff)
 	if err != nil {

--- a/feeds/pypi/pypi_test.go
+++ b/feeds/pypi/pypi_test.go
@@ -14,15 +14,15 @@ func TestPypiLatest(t *testing.T) {
 	t.Parallel()
 
 	handlers := map[string]testutils.HTTPHandlerFunc{
-		"/rss/updates.xml": updatesXMLHandle,
+		updatesPath: updatesXMLHandle,
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	baseURL = srv.URL + "/rss/updates.xml"
 	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
 	if err != nil {
-		t.Fatalf("failed to create new pypi feed: %v", err)
+		t.Fatalf("Failed to create new pypi feed: %v", err)
 	}
+	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)
@@ -63,18 +63,18 @@ func TestPypiCriticalLatest(t *testing.T) {
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	packageURLFormat = srv.URL + "/rss/project/%s/releases.xml"
 	feed, err := New(feeds.FeedOptions{
 		Packages: &packages,
 	}, events.NewNullHandler())
 	if err != nil {
-		t.Fatalf("Unexpected err: %v", err)
+		t.Fatalf("Failed to create pypi feed: %v", err)
 	}
+	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, err := feed.Latest(cutoff)
 	if err != nil {
-		t.Fatalf("failed to call Latest() with err: %v", err)
+		t.Fatalf("Failed to call Latest() with err: %v", err)
 	}
 
 	const expectedNumPackages = 4
@@ -90,16 +90,16 @@ func TestPypiCriticalLatest(t *testing.T) {
 	}
 
 	if _, ok := pkgMap["foopy"]["2.1"]; !ok {
-		t.Fatalf("missing foopy 2.1")
+		t.Fatalf("Missing foopy 2.1")
 	}
 	if _, ok := pkgMap["foopy"]["2.0"]; !ok {
-		t.Fatalf("missing foopy 2.0")
+		t.Fatalf("Missing foopy 2.0")
 	}
 	if _, ok := pkgMap["barpy"]["1.1"]; !ok {
-		t.Fatalf("missing barpy 1.1")
+		t.Fatalf("Missing barpy 1.1")
 	}
 	if _, ok := pkgMap["barpy"]["1.0"]; !ok {
-		t.Fatalf("missing barpy 1.0")
+		t.Fatalf("Missing barpy 1.0")
 	}
 }
 

--- a/feeds/rubygems/rubygems_test.go
+++ b/feeds/rubygems/rubygems_test.go
@@ -19,8 +19,8 @@ func TestRubyLatest(t *testing.T) {
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	baseURL = srv.URL + "/api/v1/activity"
 	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())
+	feed.baseURL = srv.URL
 	if err != nil {
 		t.Fatalf("failed to create new ruby feed: %v", err)
 	}


### PR DESCRIPTION
Previously multiple package tests couldn't be ran in
parallel due to the package level variables for URLs.
With these changes many package tests can be ran in
parallel without interfering with eachother.