### PR TITLE
Fix URL path encoding throughout feeds

### DIFF
--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -2,12 +2,12 @@ package crates
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -35,7 +35,11 @@ type Package struct {
 
 // Gets crates.io packages.
 func fetchPackages(baseURL string) ([]*Package, error) {
-	resp, err := httpClient.Get(fmt.Sprintf("%s%s", baseURL, activityPath))
+	pkgURL, err := utils.URLPathJoin(baseURL, activityPath)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient.Get(pkgURL)
 	if err != nil {
 		return nil, err
 	}

--- a/feeds/goproxy/goproxy.go
+++ b/feeds/goproxy/goproxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -32,10 +33,19 @@ type Package struct {
 
 func fetchPackages(baseURL string, since time.Time) ([]Package, error) {
 	var packages []Package
+	indexURL, err := utils.URLPathJoin(baseURL, indexPath)
+	if err != nil {
+		return nil, err
+	}
+	pkgURL, err := url.Parse(indexURL)
+	if err != nil {
+		return nil, err
+	}
 	params := url.Values{}
 	params.Add("since", since.Format(time.RFC3339))
-	requestURL := fmt.Sprintf("%s/%s?%s", baseURL, indexPath, params.Encode())
-	resp, err := httpClient.Get(requestURL)
+	pkgURL.RawQuery = params.Encode()
+
+	resp, err := httpClient.Get(pkgURL.String())
 	if err != nil {
 		return nil, err
 	}

--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -61,7 +61,11 @@ func (t *rfc1123Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 }
 
 func fetchPackages(baseURL string) ([]*Package, error) {
-	resp, err := httpClient.Get(fmt.Sprintf("%s/%s", baseURL, rssPath))
+	pkgURL, err := utils.URLPathJoin(baseURL, rssPath)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient.Get(pkgURL)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +81,11 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 
 // Gets the package version from the NPM.
 func fetchVersionInformation(baseURL, packageName string) (string, error) {
-	resp, err := httpClient.Get(fmt.Sprintf("%s/%s", baseURL, packageName))
+	versionURL, err := utils.URLPathJoin(baseURL, packageName)
+	if err != nil {
+		return "", err
+	}
+	resp, err := httpClient.Get(versionURL)
 	if err != nil {
 		return "", err
 	}

--- a/feeds/nuget/nuget.go
+++ b/feeds/nuget/nuget.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -56,7 +57,10 @@ type nugetPackageDetails struct {
 
 func fetchCatalogService(baseURL string) (*nugetService, error) {
 	var err error
-	catalogServiceURL := fmt.Sprintf("%s/%s", baseURL, indexPath)
+	catalogServiceURL, err := utils.URLPathJoin(baseURL, indexPath)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := httpClient.Get(catalogServiceURL)
 	if err != nil {
 		return nil, err

--- a/feeds/packagist/packagist.go
+++ b/feeds/packagist/packagist.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const FeedName = "packagist"
@@ -46,7 +47,11 @@ func New(feedOptions feeds.FeedOptions) (*Feed, error) {
 }
 
 func fetchPackages(updateHost string, since time.Time) ([]actions, error) {
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/metadata/changes.json", updateHost), nil)
+	pkgURL, err := utils.URLPathJoin(updateHost, "/metadata/changes.json")
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequest(http.MethodGet, pkgURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/feeds/rubygems/rubygems.go
+++ b/feeds/rubygems/rubygems.go
@@ -2,12 +2,12 @@ package rubygems
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/ossf/package-feeds/events"
 	"github.com/ossf/package-feeds/feeds"
+	"github.com/ossf/package-feeds/utils"
 )
 
 const (
@@ -58,7 +58,10 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	pkgs := []*feeds.Package{}
 	packages := make(map[string]*Package)
 
-	newPackagesURL := fmt.Sprintf("%s/%s/%s", feed.baseURL, activityPath, "latest.json")
+	newPackagesURL, err := utils.URLPathJoin(feed.baseURL, activityPath, "latest.json")
+	if err != nil {
+		return nil, err
+	}
 	newPackages, err := fetchPackages(newPackagesURL)
 	if err != nil {
 		return pkgs, err
@@ -66,7 +69,10 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	for _, pkg := range newPackages {
 		packages[pkg.Name] = pkg
 	}
-	updatedPackagesURL := fmt.Sprintf("%s/%s/%s", feed.baseURL, activityPath, "just_updated.json")
+	updatedPackagesURL, err := utils.URLPathJoin(feed.baseURL, activityPath, "just_updated.json")
+	if err != nil {
+		return nil, err
+	}
 	updatedPackages, err := fetchPackages(updatedPackagesURL)
 	if err != nil {
 		return pkgs, err

--- a/utils/http_requests.go
+++ b/utils/http_requests.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+)
+
+func URLPathJoin(baseURL string, paths ...string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse url: %w", err)
+	}
+	pathParts := []string{u.Path}
+	pathParts = append(pathParts, paths...)
+	u.Path = path.Join(pathParts...)
+	return u.String(), nil
+}


### PR DESCRIPTION
URL encoding was broken through joining with `fmt.Sprintf("%s/%s", ...)`, URL paths are now constructed using url parsing and `path.Join` to ensure separators are correctly handled.