### PR TITLE
Fix crates URL duplication

### DIFF
--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -74,7 +74,7 @@ func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, er
 	}
 	return &Feed{
 		lossyFeedAlerter: feeds.NewLossyFeedAlerter(eventHandler),
-		baseURL:          "https://crates.io/api/v1/summary",
+		baseURL:          "https://crates.io",
 	}, nil
 }
 


### PR DESCRIPTION
Fixes a URL duplication issues in crates likely introduced during rebase