### PR TITLE
Add support for individual feed poll timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ timer: false
 ```
 
 `poll_rate` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).This is used as an initial value to generate a cutoff point for feed events relative to the given time at execution, with subsequent events using the previous time at execution as the cutoff point.
-`timer` will configure interal polling of the `feeds` at the given `poll_rate` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
+`timer` will configure interal polling of the `feeds` at the given `poll_rate` period, individual feeds configured with a `poll_rate` will poll on an interval regardless of these options. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
 
 ## FeedOptions
 
-Feeds can be configured with additional options, not all feeds will support these features. See the appropriate feed `README.md` for supported options.
+Feeds can be configured with additional options, not all feeds will support these features. Check [feeds/README.md](feeds/README.md) for more information on feed specific configurations.
+
 Below is an example of such options with pypi being configured to poll a specific set of packages
 
 ```

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -1,0 +1,44 @@
+# Feeds
+
+Each of the feeds have their own implementation and support their own set of configuration options.
+
+## Configuration options
+
+`packages` this configuration option is only available on certain feeds, check the README of the feed you're interested in for information on this.
+
+`poll_rate` this allows for setting the frequency of polling for this specific feed. This is supported by all feeds. The value should be a string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration). Setting this value will enable the scheduled polling regardless of the value of `timer` in the root of the configuration.
+
+## Example
+
+### Poll Pypi every 5 minutes
+
+```
+feeds:
+- type: pypi
+  options:
+    poll_rate: "5m"
+```
+
+### Poll npm every 10 minutes and crates every hour
+
+```
+feeds:
+- type: npm
+  options:
+    poll_rate: "5m"
+- type: crates
+  options:
+    poll_rate: "1h"
+```
+
+### Poll a subset of pypi every 10 minutes
+
+```
+feeds:
+- type: pypi
+  options:
+    packages:
+    - numpy
+    - django
+    poll_rate: "10m"
+```

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -23,6 +23,9 @@ type FeedOptions struct {
 	// A collection of package names to poll instead of standard firehose behaviour.
 	// Not supported by all feeds.
 	Packages *[]string `yaml:"packages"`
+
+	// Cron string for scheduling the polling for the feed.
+	PollRate string `yaml:"poll_rate"`
 }
 
 // Marshalled json output validated against package.schema.json.

--- a/feeds/scheduler/feed_group.go
+++ b/feeds/scheduler/feed_group.go
@@ -26,6 +26,10 @@ func NewFeedGroup(scheduledFeeds []feeds.ScheduledFeed,
 	}
 }
 
+func (fg *FeedGroup) AddFeed(feed feeds.ScheduledFeed) {
+	fg.feeds = append(fg.feeds, feed)
+}
+
 func (fg *FeedGroup) Run() {
 	_, err := fg.PollAndPublish()
 	if err != nil {

--- a/feeds/scheduler/scheduler_test.go
+++ b/feeds/scheduler/scheduler_test.go
@@ -1,0 +1,67 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/package-feeds/feeds"
+)
+
+func TestBuildSchedules(t *testing.T) {
+	t.Parallel()
+
+	scheduledFeeds := map[string]feeds.ScheduledFeed{
+		"Foo": mockFeed{
+			packages: []*feeds.Package{
+				{Name: "Foo"},
+			},
+			options: feeds.FeedOptions{PollRate: "30s"},
+		},
+		"Bar": mockFeed{
+			packages: []*feeds.Package{
+				{Name: "Bar"},
+			},
+			options: feeds.FeedOptions{PollRate: "30s"},
+		},
+		"Baz": mockFeed{
+			packages: []*feeds.Package{
+				{Name: "Baz"},
+			},
+			options: feeds.FeedOptions{PollRate: "20s"},
+		},
+		"Qux": mockFeed{
+			packages: []*feeds.Package{
+				{Name: "Baz"},
+			},
+		},
+	}
+	cutoff := time.Minute
+	pub := mockPublisher{}
+	schedules, err := buildSchedules(scheduledFeeds, pub, cutoff)
+	if err != nil {
+		t.Fatalf("Failed to build schedules: %v", err)
+	}
+
+	defaultFg, ok := schedules[""]
+	if !ok {
+		t.Fatalf("Schedules did not contain a FeedGroup under the default schedule")
+	}
+	twentySecFg, ok := schedules["@every 20s"]
+	if !ok {
+		t.Fatalf("Schedules did not contain a FeedGroup under the 20s schedule")
+	}
+	thirtySecFg, ok := schedules["@every 30s"]
+	if !ok {
+		t.Fatalf("Schedules did not contain a FeedGroup under the 30s schedule")
+	}
+
+	if len(defaultFg.feeds) != 1 {
+		t.Fatalf("Default schedule contained %v feeds when %v was expected.", len(defaultFg.feeds), 1)
+	}
+	if len(twentySecFg.feeds) != 1 {
+		t.Fatalf("20s schedule contained %v feeds when %v was expected.", len(twentySecFg.feeds), 1)
+	}
+	if len(thirtySecFg.feeds) != 2 {
+		t.Fatalf("30s schedule contained %v feeds when %v was expected.", len(thirtySecFg.feeds), 2)
+	}
+}


### PR DESCRIPTION
This follows on from https://github.com/ossf/package-feeds/issues/85 to introduce separate polling timers for individual feeds.

Feeds are grouped and polled based on their schedules defined in FeedOptions, alternatively a default schedule is applied based upon pollRate in the root of the configuration (which runs if `timer` is enabled in the configuration).
