### PR TITLE
 feeds/: Allow for per package/feed error handling when polling

### DIFF
--- a/feeds/crates/crates.go
+++ b/feeds/crates/crates.go
@@ -80,11 +80,11 @@ func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, er
 	}, nil
 }
 
-func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 	pkgs := []*feeds.Package{}
 	packages, err := fetchPackages(feed.baseURL)
 	if err != nil {
-		return pkgs, err
+		return pkgs, []error{err}
 	}
 	for _, pkg := range packages {
 		pkg := feeds.NewPackage(pkg.UpdatedAt, pkg.Name, pkg.NewestVersion, FeedName)
@@ -93,7 +93,7 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
 	feed.lossyFeedAlerter.ProcessPackages(FeedName, pkgs)
 
 	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
-	return pkgs, nil
+	return pkgs, []error{}
 }
 
 func (feed Feed) GetName() string {

--- a/feeds/crates/crates_test.go
+++ b/feeds/crates/crates_test.go
@@ -27,8 +27,8 @@ func TestCratesLatest(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, err := feed.Latest(cutoff)
-	if err != nil {
+	pkgs, errs := feed.Latest(cutoff)
+	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 
@@ -67,11 +67,11 @@ func TestCratesNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, err = feed.Latest(cutoff)
-	if err == nil {
+	_, errs := feed.Latest(cutoff)
+	if len(errs) == 0 {
 		t.Fatalf("feed.Latest() was successful when an error was expected")
 	}
-	if !errors.Is(err, utils.ErrUnsuccessfulRequest) {
+	if !errors.Is(errs[len(errs)-1], utils.ErrUnsuccessfulRequest) {
 		t.Fatalf("feed.Latest() returned an error which did not match the expected error")
 	}
 }

--- a/feeds/feed.go
+++ b/feeds/feed.go
@@ -1,11 +1,14 @@
 package feeds
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
 
 const schemaVer = "1.0"
+
+var ErrNoPackagesPolled = errors.New("no packages were successfully polled")
 
 type UnsupportedOptionError struct {
 	Option string
@@ -13,7 +16,7 @@ type UnsupportedOptionError struct {
 }
 
 type ScheduledFeed interface {
-	Latest(cutoff time.Time) ([]*Package, error)
+	Latest(cutoff time.Time) ([]*Package, []error)
 	GetFeedOptions() FeedOptions
 	GetName() string
 }
@@ -35,6 +38,15 @@ type Package struct {
 	CreatedDate time.Time `json:"created_date"`
 	Type        string    `json:"type"`
 	SchemaVer   string    `json:"schema_ver"`
+}
+
+type PackagePollError struct {
+	Err  error
+	Name string
+}
+
+func (err PackagePollError) Error() string {
+	return fmt.Sprintf("Polling for package %s returned error: %v", err.Name, err.Err)
 }
 
 func NewPackage(created time.Time, name, version, feed string) *Package {

--- a/feeds/goproxy/goproxy.go
+++ b/feeds/goproxy/goproxy.go
@@ -100,18 +100,18 @@ func New(feedOptions feeds.FeedOptions) (*Feed, error) {
 	}, nil
 }
 
-func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 	pkgs := []*feeds.Package{}
 	packages, err := fetchPackages(feed.baseURL, cutoff)
 	if err != nil {
-		return pkgs, err
+		return pkgs, []error{err}
 	}
 	for _, pkg := range packages {
 		pkg := feeds.NewPackage(pkg.ModifiedDate, pkg.Title, pkg.Version, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
 	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
-	return pkgs, nil
+	return pkgs, []error{}
 }
 
 func (feed Feed) GetName() string {

--- a/feeds/goproxy/goproxy_test.go
+++ b/feeds/goproxy/goproxy_test.go
@@ -26,8 +26,8 @@ func TestGoProxyLatest(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, err := feed.Latest(cutoff)
-	if err != nil {
+	pkgs, errs := feed.Latest(cutoff)
+	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 
@@ -66,11 +66,11 @@ func TestGoproxyNotFound(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, err = feed.Latest(cutoff)
-	if err == nil {
+	_, errs := feed.Latest(cutoff)
+	if len(errs) == 0 {
 		t.Fatalf("feed.Latest() was successful when an error was expected")
 	}
-	if !errors.Is(err, utils.ErrUnsuccessfulRequest) {
+	if !errors.Is(errs[len(errs)-1], utils.ErrUnsuccessfulRequest) {
 		t.Fatalf("feed.Latest() returned an error which did not match the expected error")
 	}
 }

--- a/feeds/nuget/nuget_test.go
+++ b/feeds/nuget/nuget_test.go
@@ -39,9 +39,9 @@ func TestCanParseFeed(t *testing.T) {
 
 	cutoff := time.Now().Add(-5 * time.Minute)
 
-	results, err := sut.Latest(cutoff)
-	if err != nil {
-		t.Fatal(err)
+	results, errs := sut.Latest(cutoff)
+	if len(errs) != 0 {
+		t.Fatal(errs[len(errs)-1])
 	}
 
 	if len(results) != 1 {

--- a/feeds/packagist/packagist_test.go
+++ b/feeds/packagist/packagist_test.go
@@ -29,9 +29,9 @@ func TestFetch(t *testing.T) {
 	feed.versionHost = srv.URL
 
 	cutoff := time.Unix(1614513658, 0)
-	latest, err := feed.Latest(cutoff)
-	if err != nil {
-		t.Fatalf("got error: %s", err)
+	latest, errs := feed.Latest(cutoff)
+	if len(errs) != 0 {
+		t.Fatalf("got error: %v", errs[len(errs)-1])
 	}
 	if len(latest) == 0 {
 		t.Fatalf("did not get any updates")
@@ -64,11 +64,11 @@ func TestPackagistNotFound(t *testing.T) {
 	feed.versionHost = srv.URL
 
 	cutoff := time.Unix(1614513658, 0)
-	_, err = feed.Latest(cutoff)
-	if err == nil {
-		t.Fatalf("feed.Latest() was successful when an error was expected")
+	_, errs := feed.Latest(cutoff)
+	if len(errs) != 1 {
+		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}
-	if !errors.Is(err, utils.ErrUnsuccessfulRequest) {
+	if !errors.Is(errs[len(errs)-1], utils.ErrUnsuccessfulRequest) {
 		t.Fatalf("feed.Latest() returned an error which did not match the expected error")
 	}
 }

--- a/feeds/scheduler/feed_group_test.go
+++ b/feeds/scheduler/feed_group_test.go
@@ -37,9 +37,9 @@ func TestFeedGroupPoll(t *testing.T) {
 	feedGroup := NewFeedGroup(mockFeeds, pub, time.Minute)
 	startLastPollValue := feedGroup.lastPoll
 
-	pkgs, errs := feedGroup.poll()
-	if len(errs) != 0 {
-		t.Fatalf("Unexpected errors arose during polling: %v", errs)
+	pkgs, err := feedGroup.poll()
+	if err != nil {
+		t.Fatalf("Unexpected error arose during polling: %v", err)
 	}
 	if len(pkgs) != 4 {
 		t.Fatalf("poll() returned %v packages when 4 were expected", len(pkgs))
@@ -54,7 +54,7 @@ func TestFeedGroupPollWithErr(t *testing.T) {
 
 	mockFeeds := []feeds.ScheduledFeed{
 		mockFeed{
-			err: errPackage,
+			errs: []error{errPackage},
 		},
 		mockFeed{
 			packages: []*feeds.Package{
@@ -70,9 +70,9 @@ func TestFeedGroupPollWithErr(t *testing.T) {
 	feedGroup := NewFeedGroup(mockFeeds, pub, time.Minute)
 	startLastPollValue := feedGroup.lastPoll
 
-	pkgs, errs := feedGroup.poll()
-	if len(errs) != 1 {
-		t.Fatalf("Expected error during polling but error list had %v entries", len(errs))
+	pkgs, err := feedGroup.poll()
+	if err == nil {
+		t.Fatalf("Expected error during polling")
 	}
 	if len(pkgs) != 2 {
 		t.Fatalf("Expected 2 packages alongside errors but found %v", len(pkgs))

--- a/feeds/scheduler/mocks.go
+++ b/feeds/scheduler/mocks.go
@@ -9,7 +9,7 @@ import (
 
 type mockFeed struct {
 	packages []*feeds.Package
-	err      error
+	errs     []error
 	options  feeds.FeedOptions
 }
 
@@ -21,8 +21,8 @@ func (feed mockFeed) GetFeedOptions() feeds.FeedOptions {
 	return feed.options
 }
 
-func (feed mockFeed) Latest(cutoff time.Time) ([]*feeds.Package, error) {
-	return feed.packages, feed.err
+func (feed mockFeed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
+	return feed.packages, feed.errs
 }
 
 type mockPublisher struct {

--- a/feeds/scheduler/scheduler.go
+++ b/feeds/scheduler/scheduler.go
@@ -33,7 +33,7 @@ type pollResult struct {
 	name     string
 	feed     feeds.ScheduledFeed
 	packages []*feeds.Package
-	err      error
+	errs     []error
 }
 
 // Runs several services for the operation of scheduler, this call is blocking until application exit


### PR DESCRIPTION
Resolves #107 

    feeds/: Allow for per package/feed error handling when polling
    
    When errors occur but package data can still be processed then
    the system should continue where possible. This is particularly
    beneficial in feeds where data is fetched on a per package basis,
    as a singular failure shouldn't immediately lead to data loss
    for the whole session. `pollAndPublish()` error handling and
    subsequent callers have been modified to handle this.
    
    This also removes `errUnpublished` as a 'hard' error when polling
    npm for critical packages as such it is only logged.


Follow ups in the form of #101 and more tests/granular handling in nuget & packagist should also be undertaken