### PR TITLE
Add documentation for events configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ timer: false
 `poll_rate` string formatted for [duration parser](https://golang.org/pkg/time/#ParseDuration).This is used as an initial value to generate a cutoff point for feed events relative to the given time at execution, with subsequent events using the previous time at execution as the cutoff point.
 `timer` will configure interal polling of the `feeds` at the given `poll_rate` period. To specify this configuration file, define its path in your environment under the `PACKAGE_FEEDS_CONFIG_PATH` variable.
 
+An event handler can be configured through the `events` field, this is documented in the [events README](events/README.md).
+
 ## FeedOptions
 
 Feeds can be configured with additional options, not all feeds will support these features. See the appropriate feed `README.md` for supported options.

--- a/events/README.md
+++ b/events/README.md
@@ -1,0 +1,27 @@
+# Event Handling
+
+package-feeds supports publishing specific application 'events' to be processed.
+
+## Configuration
+
+```
+events:
+  sink: "stdout"
+  filter:
+    enabled_event_types: ["LOSSY_FEED"]
+    disabled_event_types: []
+    enabled_components: ["Feeds"]
+```
+
+## Events
+
+**N.B** Currently only events for potential loss during package polling are available.
+
+Types:
+- "LOSSY_FEED" - Potential loss was detected in a feed
+
+Components:
+- "Feeds" - Events which occur within feed logic
+
+Sinks:
+- "stdout" - Logs events to stdout


### PR DESCRIPTION
This resolves #97 as sufficient documentation already exists for publishers and feeds.