### PR TITLE
feeds/scheduler/feed_group.go: Handle per package errs when publishing

### DIFF
--- a/pkg/scheduler/feed_group_test.go
+++ b/pkg/scheduler/feed_group_test.go
@@ -74,6 +74,9 @@ func TestFeedGroupPollWithErr(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error during polling")
 	}
+	if !errors.Is(err, errPoll) {
+		t.Fatalf("Expected errPoll during polling")
+	}
 	if len(pkgs) != 2 {
 		t.Fatalf("Expected 2 packages alongside errors but found %v", len(pkgs))
 	}
@@ -126,5 +129,8 @@ func TestFeedGroupPublishWithErr(t *testing.T) {
 	_, err := feedGroup.publishPackages(pkgs)
 	if err == nil {
 		t.Fatalf("publishPackages provided no error when publishing produced an error")
+	}
+	if !errors.Is(err, errPub) {
+		t.Fatalf("Expected errPub during publishing")
 	}
 }


### PR DESCRIPTION
publishPackages() no longer immediately returns if a single package
fails to be marshalled or sent to the publisher. Instead the error
is logged and a generic `errPub` is returned, inline with poll().

This is for #101, however it could be extended in the future with retry logic, or even some form of `event`.