### PR TITLE
feeds/npm/npm.go: Guard against 'silent' version removal

### DIFF
--- a/feeds/npm/npm.go
+++ b/feeds/npm/npm.go
@@ -165,8 +165,16 @@ func fetchAllPackages(url string) ([]*feeds.Package, []error) {
 				errChannel <- err
 				return
 			}
-			// Apply count slice
-			packageChannel <- pkgs[:count]
+			// Apply count slice, guard against a given events corresponding
+			// version entry being unpublished by the time the specific
+			// endpoint has been processed. This seemingly happens silently
+			// without being recorded in the json. An `event` could be logged
+			// here.
+			if len(pkgs) > count {
+				packageChannel <- pkgs[:count]
+			} else {
+				packageChannel <- pkgs
+			}
 		}(pkgTitle, count)
 	}
 


### PR DESCRIPTION
This should cover the scenario where the number of package specific
'firehose' events is greater than the number of versions available
at process time. Applying the `cutoff` should prevent 'old' versions
being processed in place of the versions that triggered the events.


Resolves https://github.com/ossf/package-feeds/issues/134