### PR TITLE
feeds/scheduler/scheduler.go: Remove escaped newline from log.Infof

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -76,7 +76,7 @@ func (s *Scheduler) Run(initialCutoff time.Duration, enableDefaultTimer bool) er
 
 	// Start http server for polling via HTTP requests
 	pollServer := NewFeedGroupsHandler(feedGroups)
-	log.Infof("Listening on port %v\n", s.httpPort)
+	log.Infof("Listening on port %v", s.httpPort)
 	http.Handle("/", pollServer)
 	if err := http.ListenAndServe(fmt.Sprintf(":%v", s.httpPort), nil); err != nil {
 		return err


### PR DESCRIPTION
By default the logrus text formatter adds a newline to each field
and escapes existing characters as to not introduce empty lines.

This prevents `level=info msg="Listening on port 8080\n"`