### PR TITLE
Update terraform configuration to work with updated Google Cloud Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-terraform/.terraform
+terraform/.terraform*
 *.tfstate
 
 bin*

--- a/terraform/feeds.tf
+++ b/terraform/feeds.tf
@@ -25,8 +25,9 @@ resource "google_service_account" "run-invoker-account" {
 }
 
 resource "google_project_iam_member" "run-invoker-iam" {
-  role   = "roles/run.invoker"
-  member = "serviceAccount:${google_service_account.run-invoker-account.email}"
+  role    = "roles/run.invoker"
+  project = var.project
+  member  = "serviceAccount:${google_service_account.run-invoker-account.email}"
 }
 
 resource "google_project_service" "services" {

--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -25,6 +25,12 @@ resource "google_cloud_run_service" "run-scheduler" {
           name  = "OSSMALWARE_TOPIC_URL"
           value = "gcppubsub://${var.pubsub-topic-feed-id}"
         }
+        resources {
+          limits = {
+            memory = "512Mi"
+            cpu = "1000m"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This required explicitly setting the "project" for Run Invoker IAM role.

I also add explicit limits for the CPU and memory that match current values.