### PR TITLE
Add required id-token:write permission to scorecard workflow

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -19,6 +19,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
V2 of the scorecard workflow requires `id-token:write` otherwise it fails to work.

Signed-off-by: Caleb Brown <calebbrown@google.com>