### PR TITLE
Increase NPM feed limit, improve illegal XML character handling, remove utils.URLPathJoin 

### DIFF
--- a/pkg/feeds/crates/crates.go
+++ b/pkg/feeds/crates/crates.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/events"
@@ -36,7 +37,7 @@ type Package struct {
 
 // Gets crates.io packages.
 func fetchPackages(baseURL string) ([]*Package, error) {
-	pkgURL, err := utils.URLPathJoin(baseURL, activityPath)
+	pkgURL, err := url.JoinPath(baseURL, activityPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/goproxy/goproxy.go
+++ b/pkg/feeds/goproxy/goproxy.go
@@ -33,7 +33,7 @@ type Package struct {
 
 func fetchPackages(baseURL string, since time.Time) ([]Package, error) {
 	var packages []Package
-	indexURL, err := utils.URLPathJoin(baseURL, indexPath)
+	indexURL, err := url.JoinPath(baseURL, indexPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/npm/npm.go
+++ b/pkg/feeds/npm/npm.go
@@ -22,7 +22,7 @@ const (
 
 	// rssLimit controls how many RSS results should be returned.
 	// Can up to about 420 before the feed will consistently fail to return any data.
-	// Lower numbers will sometimes fail too. Default value if not specified is 50
+	// Lower numbers will sometimes fail too. Default value if not specified is 50.
 	rssLimit = 200
 )
 

--- a/pkg/feeds/npm/npm.go
+++ b/pkg/feeds/npm/npm.go
@@ -73,7 +73,7 @@ func fetchPackageEvents(baseURL string) ([]PackageEvent, error) {
 	}
 
 	rssResponse := &Response{}
-	reader := utils.NewUTF8OnlyReader(resp.Body, true)
+	reader := utils.NewXMLReader(resp.Body, true)
 	if err := xml.NewDecoder(reader).Decode(rssResponse); err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/npm/npm.go
+++ b/pkg/feeds/npm/npm.go
@@ -56,6 +56,7 @@ func fetchPackageEvents(baseURL string) ([]PackageEvent, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	pkgURL = pkgURL.JoinPath(rssPath)
 	q := pkgURL.Query()
 	q.Set("limit", fmt.Sprintf("%d", rssLimit))
@@ -67,13 +68,13 @@ func fetchPackageEvents(baseURL string) ([]PackageEvent, error) {
 	}
 	defer resp.Body.Close()
 
-	err = utils.CheckResponseStatus(resp)
-	if err != nil {
+	if err := utils.CheckResponseStatus(resp); err != nil {
 		return nil, fmt.Errorf("failed to fetch npm package data: %w", err)
 	}
+
 	rssResponse := &Response{}
 	reader := utils.NewUTF8OnlyReader(resp.Body, true)
-	if err = xml.NewDecoder(reader).Decode(rssResponse); err != nil {
+	if err := xml.NewDecoder(reader).Decode(rssResponse); err != nil {
 		return nil, err
 	}
 
@@ -93,8 +94,7 @@ func fetchPackage(baseURL, pkgTitle string) ([]*Package, error) {
 	}
 	defer resp.Body.Close()
 
-	err = utils.CheckResponseStatus(resp)
-	if err != nil {
+	if err := utils.CheckResponseStatus(resp); err != nil {
 		return nil, fmt.Errorf("failed to fetch npm package version data: %w", err)
 	}
 
@@ -110,8 +110,8 @@ func fetchPackage(baseURL, pkgTitle string) ([]*Package, error) {
 	var packageDetails struct {
 		Time map[string]interface{} `json:"time"`
 	}
-	err = json.Unmarshal(body, &packageDetails)
-	if err != nil {
+
+	if err := json.Unmarshal(body, &packageDetails); err != nil {
 		return nil, fmt.Errorf("%w : %w for package %s", errJSON, err, pkgTitle)
 	}
 	versions := packageDetails.Time
@@ -151,12 +151,12 @@ func fetchPackage(baseURL, pkgTitle string) ([]*Package, error) {
 	return versionSlice, nil
 }
 
-func fetchAllPackages(url string) ([]*feeds.Package, []error) {
+func fetchAllPackages(registryURL string) ([]*feeds.Package, []error) {
 	pkgs := []*feeds.Package{}
 	errs := []error{}
 	packageChannel := make(chan []*Package)
 	errChannel := make(chan error)
-	packageEvents, err := fetchPackageEvents(url)
+	packageEvents, err := fetchPackageEvents(registryURL)
 	if err != nil {
 		// If we can't generate package events then return early.
 		return pkgs, append(errs, err)
@@ -170,7 +170,7 @@ func fetchAllPackages(url string) ([]*feeds.Package, []error) {
 
 	for pkgTitle, count := range uniquePackages {
 		go func(pkgTitle string, count int) {
-			pkgs, err := fetchPackage(url, pkgTitle)
+			pkgs, err := fetchPackage(registryURL, pkgTitle)
 			if err != nil {
 				if !errors.Is(err, errUnpublished) {
 					err = feeds.PackagePollError{Name: pkgTitle, Err: err}
@@ -210,7 +210,7 @@ func fetchAllPackages(url string) ([]*feeds.Package, []error) {
 	return pkgs, errs
 }
 
-func fetchCriticalPackages(url string, packages []string) ([]*feeds.Package, []error) {
+func fetchCriticalPackages(registryURL string, packages []string) ([]*feeds.Package, []error) {
 	pkgs := []*feeds.Package{}
 	errs := []error{}
 	packageChannel := make(chan []*Package)
@@ -218,7 +218,7 @@ func fetchCriticalPackages(url string, packages []string) ([]*feeds.Package, []e
 
 	for _, pkgTitle := range packages {
 		go func(pkgTitle string) {
-			pkgs, err := fetchPackage(url, pkgTitle)
+			pkgs, err := fetchPackage(registryURL, pkgTitle)
 			if err != nil {
 				if !errors.Is(err, errUnpublished) {
 					err = feeds.PackagePollError{Name: pkgTitle, Err: err}

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -24,6 +24,7 @@ func TestNpmLatest(t *testing.T) {
 		"/QuxPackage":  quxVersionInfoResponse,
 		"/QuuxPackage": quuxVersionInfoResponse,
 	}
+
 	srv := testutils.HTTPServerMock(handlers)
 
 	feed, err := New(feeds.FeedOptions{}, events.NewNullHandler())

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -251,8 +251,9 @@ func TestNpmNonXMLResponse(t *testing.T) {
 		t.Fatalf("Expected a single package but found %v packages", len(pkgs))
 	}
 
-	if pkgs[0].Title != "@artemis-software/dok-api" {
-		t.Errorf("Package name '%v' does not match expected '%v'", pkgs[0].Title, "@artemis-software/dok-api")
+	expectedTitle := "@abcdefg-software/pog-api"
+	if pkgs[0].Title != expectedTitle {
+		t.Errorf("Package name '%v' does not match expected '%v'", pkgs[0].Title, expectedTitle)
 	}
 }
 
@@ -551,8 +552,8 @@ func nonXMLResponse(w http.ResponseWriter, r *http.Request) {
 <?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
 	<channel>
 		<item>
-			<title><![CDATA[@artemis-software/dok-api]]></title>
-			<description><![CDATA[OpenAPI client for @artemis-software/dok-api` + nonXMLChars + `]]></description>
+			<title><![CDATA[@abcdefg-software/pog-api]]></title>
+			<description><![CDATA[API client for @abcdefg-software/pog-api` + nonXMLChars + `]]></description>
 		</item>
 	</channel>
 </rss>

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -547,6 +547,7 @@ func nonUtf8Response(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, testutils.UnexpectedWriteError(err), http.StatusInternalServerError)
 	}
 }
+
 func nonXMLResponse(w http.ResponseWriter, r *http.Request) {
 	nonXMLChars := "\u0002\u0010\u0014\u0016\u001b\u0000"
 	xml := `

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -548,25 +548,11 @@ func nonUtf8Response(w http.ResponseWriter, r *http.Request) {
 func nonXMLResponse(w http.ResponseWriter, r *http.Request) {
 	nonXMLChars := "\u0002\u0010\u0014\u0016\u001b\u0000"
 	xml := `
-<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
 	<channel>
-		<title><![CDATA[npm recent updates]]></title>
-		<description><![CDATA[Updates to the npm package registry]]></description>
-		<link>https://www.npmjs.com/</link>
-		<generator>RSS for Node</generator>
-		<lastBuildDate>Wed, 05 Apr 2023 03:32:28 GMT</lastBuildDate>
-		<atom:link href="https://registry.npmjs.org/-/rss" rel="self" type="application/rss+xml"/>
-		<pubDate>Wed, 05 Apr 2023 03:32:28 GMT</pubDate>
-		<language><![CDATA[en]]></language>
-		<ttl>600</ttl>
 		<item>
 			<title><![CDATA[@artemis-software/dok-api]]></title>
-			<description><![CDATA[OpenAPI client for @artemis-software/dok-api` + nonXMLChars + `]]>
-			</description>
-			<link>https://npmjs.com/package/@artemis-software/dok-api</link>
-			<guid isPermaLink="true">https://npmjs.com/package/@artemis-software/dok-api</guid>
-			<dc:creator><![CDATA[minetoblend]]></dc:creator>
-			<pubDate>Mon, 03 Apr 2023 19:42:26 GMT</pubDate>
+			<description><![CDATA[OpenAPI client for @artemis-software/dok-api` + nonXMLChars + `]]></description>
 		</item>
 	</channel>
 </rss>

--- a/pkg/feeds/nuget/nuget.go
+++ b/pkg/feeds/nuget/nuget.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/feeds"
@@ -57,7 +58,7 @@ type nugetPackageDetails struct {
 
 func fetchCatalogService(baseURL string) (*nugetService, error) {
 	var err error
-	catalogServiceURL, err := utils.URLPathJoin(baseURL, indexPath)
+	catalogServiceURL, err := url.JoinPath(baseURL, indexPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/nuget/nuget.go
+++ b/pkg/feeds/nuget/nuget.go
@@ -133,8 +133,8 @@ func fetchCatalogPage(catalogURL string) ([]*catalogLeaf, error) {
 	return page.Packages, nil
 }
 
-func fetchPackageInfo(url string) (*nugetPackageDetails, error) {
-	resp, err := httpClient.Get(url)
+func fetchPackageInfo(infoURL string) (*nugetPackageDetails, error) {
+	resp, err := httpClient.Get(infoURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/nuget/nuget.go
+++ b/pkg/feeds/nuget/nuget.go
@@ -111,8 +111,8 @@ func fetchCatalogPages(catalogURL string) ([]*catalogPage, error) {
 	return c.Pages, nil
 }
 
-func fetchCatalogPage(url string) ([]*catalogLeaf, error) {
-	resp, err := httpClient.Get(url)
+func fetchCatalogPage(catalogURL string) ([]*catalogLeaf, error) {
+	resp, err := httpClient.Get(catalogURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/packagist/packagist.go
+++ b/pkg/feeds/packagist/packagist.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -49,7 +50,7 @@ func New(feedOptions feeds.FeedOptions) (*Feed, error) {
 }
 
 func fetchPackages(updateHost string, since time.Time) ([]actions, error) {
-	pkgURL, err := utils.URLPathJoin(updateHost, "/metadata/changes.json")
+	pkgURL, err := url.JoinPath(updateHost, "/metadata/changes.json")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feeds/pypi/pypi.go
+++ b/pkg/feeds/pypi/pypi.go
@@ -90,7 +90,7 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	}
 
 	rssResponse := &Response{}
-	reader := utils.NewUTF8OnlyReader(resp.Body, false)
+	reader := utils.NewXMLReader(resp.Body, false)
 	err = xml.NewDecoder(reader).Decode(rssResponse)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func fetchCriticalPackages(baseURL string, packageList []string) ([]*Package, []
 			}
 
 			rssResponse := &Response{}
-			reader := utils.NewUTF8OnlyReader(resp.Body, false)
+			reader := utils.NewXMLReader(resp.Body, false)
 			err = xml.NewDecoder(reader).Decode(rssResponse)
 			if err != nil {
 				errChannel <- feeds.PackagePollError{Name: pkgName, Err: err}

--- a/pkg/feeds/pypi/pypi.go
+++ b/pkg/feeds/pypi/pypi.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ func (t *rfc1123Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 }
 
 func fetchPackages(baseURL string) ([]*Package, error) {
-	pkgURL, err := utils.URLPathJoin(baseURL, updatesPath)
+	pkgURL, err := url.JoinPath(baseURL, updatesPath)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	}
 
 	rssResponse := &Response{}
-	reader := utils.NewUTF8OnlyReader(resp.Body)
+	reader := utils.NewUTF8OnlyReader(resp.Body, false)
 	err = xml.NewDecoder(reader).Decode(rssResponse)
 	if err != nil {
 		return nil, err
@@ -104,7 +105,7 @@ func fetchCriticalPackages(baseURL string, packageList []string) ([]*Package, []
 	for _, pkgName := range packageList {
 		go func(pkgName string) {
 			packageDataPath := fmt.Sprintf(packagePathFormat, pkgName)
-			pkgURL, err := utils.URLPathJoin(baseURL, packageDataPath)
+			pkgURL, err := url.JoinPath(baseURL, packageDataPath)
 			if err != nil {
 				errChannel <- feeds.PackagePollError{Name: pkgName, Err: err}
 				return
@@ -123,7 +124,7 @@ func fetchCriticalPackages(baseURL string, packageList []string) ([]*Package, []
 			}
 
 			rssResponse := &Response{}
-			reader := utils.NewUTF8OnlyReader(resp.Body)
+			reader := utils.NewUTF8OnlyReader(resp.Body, false)
 			err = xml.NewDecoder(reader).Decode(rssResponse)
 			if err != nil {
 				errChannel <- feeds.PackagePollError{Name: pkgName, Err: err}

--- a/pkg/feeds/rubygems/rubygems.go
+++ b/pkg/feeds/rubygems/rubygems.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/events"
@@ -68,7 +69,7 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 	packages := make(map[string]*Package)
 	var errs []error
 
-	newPackagesURL, err := utils.URLPathJoin(feed.baseURL, activityPath, "latest.json")
+	newPackagesURL, err := url.JoinPath(feed.baseURL, activityPath, "latest.json")
 	if err != nil {
 		// Failure to construct a url should lead to a hard failure.
 		return nil, append(errs, err)
@@ -82,7 +83,7 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 			packages[pkg.Name] = pkg
 		}
 	}
-	updatedPackagesURL, err := utils.URLPathJoin(feed.baseURL, activityPath, "just_updated.json")
+	updatedPackagesURL, err := url.JoinPath(feed.baseURL, activityPath, "just_updated.json")
 	if err != nil {
 		// Failure to construct a url should lead to a hard failure.
 		return nil, append(errs, err)

--- a/pkg/feeds/rubygems/rubygems.go
+++ b/pkg/feeds/rubygems/rubygems.go
@@ -27,8 +27,8 @@ type Package struct {
 	CreatedDate time.Time `json:"version_created_at"`
 }
 
-func fetchPackages(url string) ([]*Package, error) {
-	resp, err := httpClient.Get(url)
+func fetchPackages(packagesURL string) ([]*Package, error) {
+	resp, err := httpClient.Get(packagesURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/http_requests.go
+++ b/pkg/utils/http_requests.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 var ErrUnsuccessfulRequest = errors.New("unsuccessful request")
@@ -15,15 +13,4 @@ func CheckResponseStatus(res *http.Response) error {
 		return fmt.Errorf("%w: %v", ErrUnsuccessfulRequest, res.Status)
 	}
 	return nil
-}
-
-func URLPathJoin(baseURL string, paths ...string) (string, error) {
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse url: %w", err)
-	}
-	pathParts := []string{u.Path}
-	pathParts = append(pathParts, paths...)
-	u.Path = path.Join(pathParts...)
-	return u.String(), nil
 }

--- a/pkg/utils/utf8_decoder.go
+++ b/pkg/utils/utf8_decoder.go
@@ -8,7 +8,7 @@ import (
 )
 
 // UTF8OnlyReader implements a Reader which ignores non utf-8 characters.
-// Optionally, it can also replace non-XML characters with U+25A1 (□)
+// Optionally, it can also replace non-XML characters with U+25A1 (□).
 type UTF8OnlyReader struct {
 	buffer             *bufio.Reader
 	replaceNonXMLChars bool
@@ -16,14 +16,14 @@ type UTF8OnlyReader struct {
 
 // NewUTF8OnlyReader wraps a new UTF8OnlyReader around an existing reader.
 // If replaceNonXMLChars is true, the reader will replace all invalid XML
-// characters with the unicode replacement character
+// characters with the unicode replacement character.
 func NewUTF8OnlyReader(rd io.Reader, replaceNonXMLChars bool) UTF8OnlyReader {
 	return UTF8OnlyReader{bufio.NewReader(rd), replaceNonXMLChars}
 }
 
 // Returns true iff the given rune is in the XML Character Range, as defined
 // by https://www.xml.com/axml/testaxml.htm, Section 2.2 Characters.
-// Implementation copied from xml/xml.go
+// Implementation copied from xml/xml.go.
 func isInCharacterRange(r rune) bool {
 	return r == 0x09 || r == 0x0A || r == 0x0D ||
 		r >= 0x20 && r <= 0xD7FF ||

--- a/pkg/utils/utf8_decoder.go
+++ b/pkg/utils/utf8_decoder.go
@@ -7,33 +7,59 @@ import (
 	"unicode/utf8"
 )
 
-// ValidUTF8Reader implements a Reader which ignores non utf-8 characters.
+// UTF8OnlyReader implements a Reader which ignores non utf-8 characters.
+// Optionally, it can also replace non-XML characters with U+25A1 (□)
 type UTF8OnlyReader struct {
-	buffer *bufio.Reader
+	buffer             *bufio.Reader
+	replaceNonXMLChars bool
 }
 
-// NewValidUTF8Reader wraps a new UTF8OnlyReader around an existing reader.
-func NewUTF8OnlyReader(rd io.Reader) UTF8OnlyReader {
-	return UTF8OnlyReader{bufio.NewReader(rd)}
+// NewUTF8OnlyReader wraps a new UTF8OnlyReader around an existing reader.
+// If replaceNonXMLChars is true, the reader will replace all invalid XML
+// characters with the unicode replacement character
+func NewUTF8OnlyReader(rd io.Reader, replaceNonXMLChars bool) UTF8OnlyReader {
+	return UTF8OnlyReader{bufio.NewReader(rd), replaceNonXMLChars}
+}
+
+// Returns true iff the given rune is in the XML Character Range, as defined
+// by https://www.xml.com/axml/testaxml.htm, Section 2.2 Characters.
+// Implementation copied from xml/xml.go
+func isInCharacterRange(r rune) bool {
+	return r == 0x09 || r == 0x0A || r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
 }
 
 // Reads bytes into the byte array b whilst ignoring non utf-8 characters
 // Returns the number of bytes read and an error if one occurs.
 func (reader UTF8OnlyReader) Read(b []byte) (int, error) {
-	var numBytesRead int
+	numBytesRead := 0
 	for {
 		r, runeSize, err := reader.buffer.ReadRune()
 		if err != nil {
 			return numBytesRead, err
 		}
 
-		// Ignore non utf-8 characters
+		// Invalid UTF-8 characters are represented with r set to utf8.RuneError
+		// (i.e. Unicode replacement character) and read size of 1
+		if r == utf8.RuneError && runeSize == 1 {
+			continue
+		}
+
+		// Also ignore the replacement character for compatibility with previous behaviour
+		// (yes, utf8.RuneError == unicode.ReplacementChar)
 		if r == unicode.ReplacementChar {
 			continue
 		}
 
+		if reader.replaceNonXMLChars && !isInCharacterRange(r) {
+			r = '\u25A1' // □ (symbol for missing character)
+			runeSize = utf8.RuneLen(r)
+		}
+
 		// Finish Read if we don't have enough space for this rune in the output byte slice
-		if len(b)-numBytesRead <= runeSize {
+		if numBytesRead+runeSize >= len(b) {
 			err = reader.buffer.UnreadRune()
 			return numBytesRead, err
 		}


### PR DESCRIPTION
- adds customisable limit to NPM RSS feed, which allows querying a greater number of packages at once
- rename `utils.UTF8OnlyReader` to `utils.XMLReader`
- fixes handling of illegal XML characters in RSS feeds by adding an option to `utils.NewXMLReader` (renamed from `utils.NewUTF8OnlyDecoder`) to replace non-XML characters with the □ character 
- replaces custom function `utils.URLPathJoin()` with library function `url.JoinPath` with the same semantics except in unused edge cases

Fixes #171 