### PR TITLE
Change default NPM poll rate to 2 minutes

### DIFF
--- a/pkg/config/scheduledfeed.go
+++ b/pkg/config/scheduledfeed.go
@@ -34,7 +34,7 @@ var (
 	errUnknownSinkType = errors.New("unknown sink type")
 
 	// feed-specific poll rate is left unspecified, so it can still be
-	// configured by the global 'poll_rate' option in the ScheduledFeedConfig YAML
+	// configured by the global 'poll_rate' option in the ScheduledFeedConfig YAML.
 	defaultFeedOptions    = feeds.FeedOptions{Packages: nil, PollRate: ""}
 	npmDefaultFeedOptions = feeds.FeedOptions{Packages: nil, PollRate: "2m"}
 )

--- a/pkg/config/scheduledfeed.go
+++ b/pkg/config/scheduledfeed.go
@@ -32,6 +32,11 @@ var (
 	errUnknownFeed     = errors.New("unknown feed type")
 	errUnknownPub      = errors.New("unknown publisher type")
 	errUnknownSinkType = errors.New("unknown sink type")
+
+	// feed-specific poll rate is left unspecified, so it can still be
+	// configured by the global 'poll_rate' option in the ScheduledFeedConfig YAML
+	defaultFeedOptions    = feeds.FeedOptions{Packages: nil, PollRate: ""}
+	npmDefaultFeedOptions = feeds.FeedOptions{Packages: nil, PollRate: "2m"}
 )
 
 // Loads a ScheduledFeedConfig struct from a yaml config file.
@@ -193,13 +198,34 @@ func strictDecode(input, out interface{}) error {
 func Default() *ScheduledFeedConfig {
 	config := &ScheduledFeedConfig{
 		Feeds: []FeedConfig{
-			{Type: crates.FeedName},
-			{Type: goproxy.FeedName},
-			{Type: npm.FeedName},
-			{Type: nuget.FeedName},
-			{Type: packagist.FeedName},
-			{Type: pypi.FeedName},
-			{Type: rubygems.FeedName},
+			{
+				Type:    crates.FeedName,
+				Options: defaultFeedOptions,
+			},
+			{
+				Type:    goproxy.FeedName,
+				Options: defaultFeedOptions,
+			},
+			{
+				Type:    npm.FeedName,
+				Options: npmDefaultFeedOptions,
+			},
+			{
+				Type:    nuget.FeedName,
+				Options: defaultFeedOptions,
+			},
+			{
+				Type:    packagist.FeedName,
+				Options: defaultFeedOptions,
+			},
+			{
+				Type:    pypi.FeedName,
+				Options: defaultFeedOptions,
+			},
+			{
+				Type:    rubygems.FeedName,
+				Options: defaultFeedOptions,
+			},
 		},
 		PubConfig: PublisherConfig{
 			Type: stdout.PublisherType,


### PR DESCRIPTION
Follow up to #171 and #312, increases polling rate for NPM feed only. Note, this now means that NPM poll rate can't be configured via the global YAML; overrides must be done using the NPM-specific yaml config. 