### PR TITLE
pypi RSS feed: replace non-XML characters with unicode square

### DIFF
--- a/pkg/feeds/pypi/pypi.go
+++ b/pkg/feeds/pypi/pypi.go
@@ -90,7 +90,7 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	}
 
 	rssResponse := &Response{}
-	reader := utils.NewXMLReader(resp.Body, false)
+	reader := utils.NewXMLReader(resp.Body, true)
 	err = xml.NewDecoder(reader).Decode(rssResponse)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func fetchCriticalPackages(baseURL string, packageList []string) ([]*Package, []
 			}
 
 			rssResponse := &Response{}
-			reader := utils.NewXMLReader(resp.Body, false)
+			reader := utils.NewXMLReader(resp.Body, true)
 			err = xml.NewDecoder(reader).Decode(rssResponse)
 			if err != nil {
 				errChannel <- feeds.PackagePollError{Name: pkgName, Err: err}


### PR DESCRIPTION
The PyPI RSS feed has the same XML issue as the NPM one had, which was fixed in #312.
This PR applies the same fix to the PyPI RSS feed