### PR TITLE
Up the number of max idle conns allowed per host.

### DIFF
--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -13,6 +14,10 @@ import (
 )
 
 func main() {
+	// Increase idle conns per host to increase the reuse of existing
+	// connections between requests.
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 8
+
 	configPath, useConfig := os.LookupEnv("PACKAGE_FEEDS_CONFIG_PATH")
 	var err error
 


### PR DESCRIPTION
By default Go sets the value to 2, which means keep-alive is only used for 2 connections, slowing down requests, and potentially causing unnecessary timeouts.