### PR TITLE
Add a pool of workers for fetching package from the NPM registry

### DIFF
--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	// Increase idle conns per host to increase the reuse of existing
 	// connections between requests.
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 8
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 10
 
 	configPath, useConfig := os.LookupEnv("PACKAGE_FEEDS_CONFIG_PATH")
 	var err error

--- a/cmd/scheduled-feed/main.go
+++ b/cmd/scheduled-feed/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -13,6 +14,10 @@ import (
 )
 
 func main() {
+	// Increase idle conns per host to increase the reuse of existing
+	// connections between requests.
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 8
+
 	configPath, useConfig := os.LookupEnv("PACKAGE_FEEDS_CONFIG_PATH")
 	var err error
 

--- a/pkg/feeds/npm/npm.go
+++ b/pkg/feeds/npm/npm.go
@@ -183,37 +183,43 @@ func fetchAllPackages(registryURL string) ([]*feeds.Package, []error) {
 		pkgTitle string
 		count    int
 	})
+
 	var wg sync.WaitGroup
+
+	// Define the fetcher function that grabs the repos from NPM
+	fetcherFn := func() {
+		defer wg.Done()
+		for {
+			w, more := <-workChannel
+			if !more {
+				// If we have no more work then return.
+				return
+			}
+			pkgs, err := fetchPackage(registryURL, w.pkgTitle)
+			if err != nil {
+				if !errors.Is(err, errUnpublished) {
+					err = feeds.PackagePollError{Name: w.pkgTitle, Err: err}
+				}
+				errChannel <- err
+				continue
+			}
+			// Apply count slice, guard against a given events corresponding
+			// version entry being unpublished by the time the specific
+			// endpoint has been processed. This seemingly happens silently
+			// without being recorded in the json. An `event` could be logged
+			// here.
+			if len(pkgs) > w.count {
+				packageChannel <- pkgs[:w.count]
+			} else {
+				packageChannel <- pkgs
+			}
+		}
+	}
+
+	// Start the fetcher workers.
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			for {
-				w, more := <-workChannel
-				if !more {
-					// If we have no more work then return.
-					return
-				}
-				pkgs, err := fetchPackage(registryURL, w.pkgTitle)
-				if err != nil {
-					if !errors.Is(err, errUnpublished) {
-						err = feeds.PackagePollError{Name: w.pkgTitle, Err: err}
-					}
-					errChannel <- err
-					continue
-				}
-				// Apply count slice, guard against a given events corresponding
-				// version entry being unpublished by the time the specific
-				// endpoint has been processed. This seemingly happens silently
-				// without being recorded in the json. An `event` could be logged
-				// here.
-				if len(pkgs) > w.count {
-					packageChannel <- pkgs[:w.count]
-				} else {
-					packageChannel <- pkgs
-				}
-			}
-		}(i)
+		go fetcherFn()
 	}
 
 	// Start a consumer to collect the output of the packages


### PR DESCRIPTION
This limits the amount of simultaneous requests and should lower the
likelihood of errors being produced when querying NPM.

MaxIdleConnsPerHost is bumped to equal the number of workers.