### PR TITLE
Bump the memory limit as the job is running out of memory.

### DIFF
--- a/terraform/scheduler/main.tf
+++ b/terraform/scheduler/main.tf
@@ -27,7 +27,7 @@ resource "google_cloud_run_service" "run-scheduler" {
         }
         resources {
           limits = {
-            memory = "512Mi"
+            memory = "2Gi"
             cpu = "1000m"
           }
         }


### PR DESCRIPTION
Feeds is currently hitting the 512Mb limit regularly.