### PR TITLE
Force HTTP1 for NPM and reintroduce a worker pool.

### DIFF
--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -221,7 +221,7 @@ func TestNpmNonUtf8Response(t *testing.T) {
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	pkgs, err := fetchPackageEvents(srv.URL)
+	pkgs, err := fetchPackageEvents(http.DefaultClient, srv.URL)
 	if err != nil {
 		t.Fatalf("Failed to fetch packages: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestNpmNonXMLResponse(t *testing.T) {
 	}
 	srv := testutils.HTTPServerMock(handlers)
 
-	pkgs, err := fetchPackageEvents(srv.URL)
+	pkgs, err := fetchPackageEvents(http.DefaultClient, srv.URL)
 	if err != nil {
 		t.Fatalf("Failed to fetch packages: %v", err)
 	}


### PR DESCRIPTION
HTTP2 appears to be struggling with the large responses from NPM and flow control.

Since this appears to be an issue inherent in HTTP2 and without wanting to delve into the complex task of tuning HTTP2 flow control parameters we fall back to pipelining in HTTP1.