### PR TITLE
Allow ScheduledFeed.Latest to return a cutoff for future invocations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - asciicheck
     - bodyclose
     - deadcode
-    - depguard
+    #- depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO ?= go
 BIN := bin
 GOOS ?= $(shell uname | tr A-Z a-z)
-GOLANGCI_LINT_VERSION = v1.51.2
+GOLANGCI_LINT_VERSION = v1.53.3
 PROJECT := package-feeds
 
 .PHONY: help

--- a/pkg/feeds/crates/crates.go
+++ b/pkg/feeds/crates/crates.go
@@ -81,11 +81,11 @@ func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, er
 	}, nil
 }
 
-func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
 	pkgs := []*feeds.Package{}
 	packages, err := fetchPackages(feed.baseURL)
 	if err != nil {
-		return pkgs, []error{err}
+		return pkgs, cutoff, []error{err}
 	}
 	for _, pkg := range packages {
 		pkg := feeds.NewPackage(pkg.UpdatedAt, pkg.Name, pkg.NewestVersion, FeedName)
@@ -93,8 +93,9 @@ func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 	}
 	feed.lossyFeedAlerter.ProcessPackages(FeedName, pkgs)
 
+	newCutoff := feeds.FindCutoff(cutoff, pkgs)
 	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
-	return pkgs, []error{}
+	return pkgs, newCutoff, []error{}
 }
 
 func (feed Feed) GetName() string {

--- a/pkg/feeds/crates/crates_test.go
+++ b/pkg/feeds/crates/crates_test.go
@@ -31,6 +31,8 @@ func TestCratesLatest(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
+
+	// Time should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 3, 19, 13, 36, 33, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/crates/crates_test.go
+++ b/pkg/feeds/crates/crates_test.go
@@ -27,9 +27,13 @@ func TestCratesLatest(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+	wantCutoff := time.Date(2021, 3, 19, 13, 36, 33, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	if pkgs[0].Name != "FooPackage" {
@@ -67,7 +71,10 @@ func TestCratesNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) == 0 {
 		t.Fatalf("feed.Latest() was successful when an error was expected")
 	}

--- a/pkg/feeds/crates/crates_test.go
+++ b/pkg/feeds/crates/crates_test.go
@@ -32,7 +32,7 @@ func TestCratesLatest(t *testing.T) {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 
-	// Time should match the newest package creation time of packages retrieved.
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 3, 19, 13, 36, 33, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/feed.go
+++ b/pkg/feeds/feed.go
@@ -15,13 +15,6 @@ type UnsupportedOptionError struct {
 	Feed   string
 }
 
-// Cutoff is an interface used to define orering of package updates.
-//
-// The type *time.Time satisifies this interface.
-type Cutoff[T any] interface {
-	Before(Cutoff[T]) bool
-}
-
 type ScheduledFeed interface {
 	Latest(cutoff time.Time) ([]*Package, time.Time, []error)
 	GetFeedOptions() FeedOptions

--- a/pkg/feeds/goproxy/goproxy.go
+++ b/pkg/feeds/goproxy/goproxy.go
@@ -100,18 +100,19 @@ func New(feedOptions feeds.FeedOptions) (*Feed, error) {
 	}, nil
 }
 
-func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
+func (feed Feed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
 	pkgs := []*feeds.Package{}
 	packages, err := fetchPackages(feed.baseURL, cutoff)
 	if err != nil {
-		return pkgs, []error{err}
+		return pkgs, cutoff, []error{err}
 	}
 	for _, pkg := range packages {
 		pkg := feeds.NewPackage(pkg.ModifiedDate, pkg.Title, pkg.Version, FeedName)
 		pkgs = append(pkgs, pkg)
 	}
+	newCutoff := feeds.FindCutoff(cutoff, pkgs)
 	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
-	return pkgs, []error{}
+	return pkgs, newCutoff, []error{}
 }
 
 func (feed Feed) GetName() string {

--- a/pkg/feeds/goproxy/goproxy_test.go
+++ b/pkg/feeds/goproxy/goproxy_test.go
@@ -26,11 +26,15 @@ func TestGoProxyLatest(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 
+	wantCutoff := time.Date(2019, 4, 10, 20, 30, 2, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
+	}
 	if pkgs[0].Name != "golang.org/x/foo" {
 		t.Errorf("Unexpected package `%s` found in place of expected `golang.org/x/foo`", pkgs[0].Name)
 	}
@@ -66,7 +70,10 @@ func TestGoproxyNotFound(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) == 0 {
 		t.Fatalf("feed.Latest() was successful when an error was expected")
 	}

--- a/pkg/feeds/goproxy/goproxy_test.go
+++ b/pkg/feeds/goproxy/goproxy_test.go
@@ -31,6 +31,7 @@ func TestGoProxyLatest(t *testing.T) {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2019, 4, 10, 20, 30, 2, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -35,9 +35,15 @@ func TestNpmLatest(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, _, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", errs[len(errs)-1])
+	}
+
+	// Returned cutoff should match the newest package creation time of packages retrieved.
+	wantCutoff := time.Date(2021, 5, 11, 18, 32, 1, 0, time.UTC)
+	if gotCutoff != wantCutoff {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	if pkgs[0].Name != "FooPackage" {
@@ -145,6 +151,7 @@ func TestNpmCritical(t *testing.T) {
 		t.Fatalf("Latest() produced %v packages instead of the expected 7", len(pkgs))
 	}
 
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 5, 11, 18, 32, 1, 0, time.UTC)
 	if gotCutoff != wantCutoff {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/npm/npm_test.go
+++ b/pkg/feeds/npm/npm_test.go
@@ -35,7 +35,7 @@ func TestNpmLatest(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", errs[len(errs)-1])
 	}
@@ -136,13 +136,18 @@ func TestNpmCritical(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("Failed to call Latest() with err: %v", errs[len(errs)-1])
 	}
 
 	if len(pkgs) != 5 {
 		t.Fatalf("Latest() produced %v packages instead of the expected 7", len(pkgs))
+	}
+
+	wantCutoff := time.Date(2021, 5, 11, 18, 32, 1, 0, time.UTC)
+	if gotCutoff != wantCutoff {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	pkgMap := map[string]map[string]*feeds.Package{}
@@ -192,7 +197,7 @@ func TestNpmCriticalUnpublished(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
@@ -274,7 +279,10 @@ func TestNpmNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) != 2 {
 		t.Fatalf("feed.Latest() returned %v errors when 2 were expected", len(errs))
 	}
@@ -304,7 +312,7 @@ func TestNpmPartialNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}
@@ -343,7 +351,7 @@ func TestNpmCriticalPartialNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}

--- a/pkg/feeds/nuget/nuget_test.go
+++ b/pkg/feeds/nuget/nuget_test.go
@@ -39,9 +39,14 @@ func TestCanParseFeed(t *testing.T) {
 
 	cutoff := time.Now().Add(-5 * time.Minute)
 
-	results, errs := sut.Latest(cutoff)
+	results, gotCutoff, errs := sut.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatal(errs[len(errs)-1])
+	}
+
+	wantCutoff := time.Now().UTC()
+	if gotCutoff == cutoff || gotCutoff.Sub(wantCutoff).Abs() > (70*time.Second) {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	if len(results) != 1 {

--- a/pkg/feeds/nuget/nuget_test.go
+++ b/pkg/feeds/nuget/nuget_test.go
@@ -44,6 +44,9 @@ func TestCanParseFeed(t *testing.T) {
 		t.Fatal(errs[len(errs)-1])
 	}
 
+	// Returned cutoff should match the newest package creation time of packages retrieved.
+	// This time is automatically generated at approx 1 minutes ago. The threshold of 70s
+	// ensures this test doesn't fail with the multiple mocked API requests.
 	wantCutoff := time.Now().UTC()
 	if gotCutoff == cutoff || gotCutoff.Sub(wantCutoff).Abs() > (70*time.Second) {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/packagist/packagist.go
+++ b/pkg/feeds/packagist/packagist.go
@@ -115,12 +115,12 @@ func fetchVersionInformation(versionHost string, action actions) ([]*feeds.Packa
 }
 
 // Latest returns all package updates of packagist packages since cutoff.
-func (f Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
+func (f Feed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
 	pkgs := []*feeds.Package{}
 	var errs []error
 	packages, err := fetchPackages(f.updateHost, cutoff)
 	if err != nil {
-		return nil, append(errs, err)
+		return nil, cutoff, append(errs, err)
 	}
 	for _, pkg := range packages {
 		if time.Unix(pkg.Time, 0).Before(cutoff) {
@@ -136,8 +136,9 @@ func (f Feed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
 		}
 		pkgs = append(pkgs, updates...)
 	}
+	newCutoff := feeds.FindCutoff(cutoff, pkgs)
 	pkgs = feeds.ApplyCutoff(pkgs, cutoff)
-	return pkgs, errs
+	return pkgs, newCutoff, errs
 }
 
 func (f Feed) GetName() string {

--- a/pkg/feeds/packagist/packagist_test.go
+++ b/pkg/feeds/packagist/packagist_test.go
@@ -36,6 +36,8 @@ func TestFetch(t *testing.T) {
 	if len(latest) == 0 {
 		t.Fatalf("did not get any updates")
 	}
+
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 2, 28, 12, 20, 3, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/packagist/packagist_test.go
+++ b/pkg/feeds/packagist/packagist_test.go
@@ -29,12 +29,16 @@ func TestFetch(t *testing.T) {
 	feed.versionHost = srv.URL
 
 	cutoff := time.Unix(1614513658, 0)
-	latest, errs := feed.Latest(cutoff)
+	latest, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("got error: %v", errs[len(errs)-1])
 	}
 	if len(latest) == 0 {
 		t.Fatalf("did not get any updates")
+	}
+	wantCutoff := time.Date(2021, 2, 28, 12, 20, 3, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 	for _, pkg := range latest {
 		if pkg.CreatedDate.Before(cutoff) {
@@ -64,7 +68,10 @@ func TestPackagistNotFound(t *testing.T) {
 	feed.versionHost = srv.URL
 
 	cutoff := time.Unix(1614513658, 0)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}

--- a/pkg/feeds/pypi/pypi_artifacts.go
+++ b/pkg/feeds/pypi/pypi_artifacts.go
@@ -29,18 +29,19 @@ func NewArtifactFeed(feedOptions feeds.FeedOptions) (*ArtifactFeed, error) {
 	}, nil
 }
 
-func (feed ArtifactFeed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
+func (feed ArtifactFeed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
 	client, err := xmlrpc.NewClient(feed.baseURL, nil)
 	if err != nil {
-		return nil, []error{err}
+		return nil, cutoff, []error{err}
 	}
 
 	changelogEntries, err := getPyPIChangeLog(client, cutoff)
 	if err != nil {
-		return nil, []error{err}
+		return nil, cutoff, []error{err}
 	}
 
-	return getUploadedArtifacts(changelogEntries), nil
+	pkgs := getUploadedArtifacts(changelogEntries)
+	return pkgs, feeds.FindCutoff(cutoff, pkgs), nil
 }
 
 func (feed ArtifactFeed) GetFeedOptions() feeds.FeedOptions {

--- a/pkg/feeds/pypi/pypi_artifacts_test.go
+++ b/pkg/feeds/pypi/pypi_artifacts_test.go
@@ -408,7 +408,7 @@ func TestPyPIArtifactsLive(t *testing.T) {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
 	wantCutoff := time.Now().UTC()
-	if gotCutoff.Sub(wantCutoff).Abs() > time.Minute {
+	if gotCutoff.Sub(wantCutoff).Abs() > 5*time.Minute {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 

--- a/pkg/feeds/pypi/pypi_artifacts_test.go
+++ b/pkg/feeds/pypi/pypi_artifacts_test.go
@@ -403,9 +403,13 @@ func TestPyPIArtifactsLive(t *testing.T) {
 	}
 
 	cutoff := time.Now().AddDate(0, 0, -1)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+	wantCutoff := time.Now().UTC()
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Minute {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	for _, p := range pkgs {

--- a/pkg/feeds/pypi/pypi_artifacts_test.go
+++ b/pkg/feeds/pypi/pypi_artifacts_test.go
@@ -407,9 +407,13 @@ func TestPyPIArtifactsLive(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
-	wantCutoff := time.Now().UTC()
-	if gotCutoff.Sub(wantCutoff).Abs() > 5*time.Minute {
-		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
+
+	if cutoff == gotCutoff {
+		t.Errorf("Latest() cutoff did not change")
+	}
+
+	if len(pkgs) == 0 {
+		t.Fatalf("Latest() returned no packages")
 	}
 
 	for _, p := range pkgs {

--- a/pkg/feeds/pypi/pypi_test.go
+++ b/pkg/feeds/pypi/pypi_test.go
@@ -27,9 +27,13 @@ func TestPypiLatest(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
+	}
+	wantCutoff := time.Date(2021, 3, 19, 12, 1, 4, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	if pkgs[0].Name != "FooPackage" {
@@ -74,9 +78,13 @@ func TestPypiCriticalLatest(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("Failed to call Latest() with err: %v", errs[len(errs)-1])
+	}
+	wantCutoff := time.Date(2021, 3, 27, 22, 16, 26, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	const expectedNumPackages = 4
@@ -127,7 +135,10 @@ func TestPypiAllNotFound(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) != 3 {
 		t.Fatalf("feed.Latest() returned %v errors when 3 were expected", len(errs))
 	}
@@ -158,7 +169,7 @@ func TestPypiCriticalPartialNotFound(t *testing.T) {
 	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}

--- a/pkg/feeds/pypi/pypi_test.go
+++ b/pkg/feeds/pypi/pypi_test.go
@@ -31,6 +31,8 @@ func TestPypiLatest(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", err)
 	}
+
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 3, 19, 12, 1, 4, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
@@ -82,6 +84,8 @@ func TestPypiCriticalLatest(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("Failed to call Latest() with err: %v", errs[len(errs)-1])
 	}
+
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 3, 27, 22, 16, 26, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/rubygems/rubygems_test.go
+++ b/pkg/feeds/rubygems/rubygems_test.go
@@ -32,6 +32,8 @@ func TestRubyLatest(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", errs[len(errs)-1])
 	}
+
+	// Returned cutoff should match the newest package creation time of packages retrieved.
 	wantCutoff := time.Date(2021, 3, 19, 13, 0, 43, 0, time.UTC)
 	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
 		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)

--- a/pkg/feeds/rubygems/rubygems_test.go
+++ b/pkg/feeds/rubygems/rubygems_test.go
@@ -28,9 +28,13 @@ func TestRubyLatest(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
 		t.Fatalf("feed.Latest returned error: %v", errs[len(errs)-1])
+	}
+	wantCutoff := time.Date(2021, 3, 19, 13, 0, 43, 0, time.UTC)
+	if gotCutoff.Sub(wantCutoff).Abs() > time.Second {
+		t.Errorf("Latest() cutoff %v, want %v", gotCutoff, wantCutoff)
 	}
 
 	var fooPkg *feeds.Package
@@ -78,7 +82,10 @@ func TestRubyGemsNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	_, errs := feed.Latest(cutoff)
+	_, gotCutoff, errs := feed.Latest(cutoff)
+	if cutoff != gotCutoff {
+		t.Error("feed.Latest() cutoff should be unchanged if an error is returned")
+	}
 	if len(errs) == 0 {
 		t.Fatalf("feed.Latest() was successful when an error was expected")
 	}
@@ -103,7 +110,7 @@ func TestRubyGemsPartialNotFound(t *testing.T) {
 	}
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	pkgs, errs := feed.Latest(cutoff)
+	pkgs, _, errs := feed.Latest(cutoff)
 	if len(errs) != 1 {
 		t.Fatalf("feed.Latest() returned %v errors when 1 was expected", len(errs))
 	}

--- a/pkg/scheduler/feed_group_test.go
+++ b/pkg/scheduler/feed_group_test.go
@@ -35,7 +35,6 @@ func TestFeedGroupPoll(t *testing.T) {
 	var pub publisher.Publisher = mockPub
 
 	feedGroup := NewFeedGroup(mockFeeds, pub, time.Minute)
-	startLastPollValue := feedGroup.lastPoll
 
 	pkgs, err := feedGroup.poll()
 	if err != nil {
@@ -43,9 +42,6 @@ func TestFeedGroupPoll(t *testing.T) {
 	}
 	if len(pkgs) != 4 {
 		t.Fatalf("poll() returned %v packages when 4 were expected", len(pkgs))
-	}
-	if startLastPollValue.Equal(feedGroup.lastPoll) {
-		t.Fatalf("Feed Group did not update last poll as expected")
 	}
 }
 
@@ -68,7 +64,6 @@ func TestFeedGroupPollWithErr(t *testing.T) {
 	var pub publisher.Publisher = mockPub
 
 	feedGroup := NewFeedGroup(mockFeeds, pub, time.Minute)
-	startLastPollValue := feedGroup.lastPoll
 
 	pkgs, err := feedGroup.poll()
 	if err == nil {
@@ -79,9 +74,6 @@ func TestFeedGroupPollWithErr(t *testing.T) {
 	}
 	if len(pkgs) != 2 {
 		t.Fatalf("Expected 2 packages alongside errors but found %v", len(pkgs))
-	}
-	if startLastPollValue.Equal(feedGroup.lastPoll) {
-		t.Fatalf("Feed Group did not update last poll as expected")
 	}
 }
 

--- a/pkg/scheduler/mocks.go
+++ b/pkg/scheduler/mocks.go
@@ -1,3 +1,4 @@
+//nolint:gocritic
 package scheduler
 
 import (

--- a/pkg/scheduler/mocks.go
+++ b/pkg/scheduler/mocks.go
@@ -10,6 +10,7 @@ import (
 type mockFeed struct {
 	packages []*feeds.Package
 	errs     []error
+	cutoff   time.Time
 	options  feeds.FeedOptions
 }
 
@@ -21,8 +22,8 @@ func (feed mockFeed) GetFeedOptions() feeds.FeedOptions {
 	return feed.options
 }
 
-func (feed mockFeed) Latest(cutoff time.Time) ([]*feeds.Package, []error) {
-	return feed.packages, feed.errs
+func (feed mockFeed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
+	return feed.packages, feed.cutoff, feed.errs
 }
 
 type mockPublisher struct {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -58,7 +58,7 @@ func (s *Scheduler) Run(initialCutoff time.Duration, enableDefaultTimer bool) er
 	for schedule, feedGroup := range schedules {
 		var feedNames []string
 		for _, f := range feedGroup.feeds {
-			feedNames = append(feedNames, f.GetName())
+			feedNames = append(feedNames, f.feed.GetName())
 		}
 
 		if schedule == "" {


### PR DESCRIPTION
This fixes #382 by ensuring each feed uses a cutoff value that is based on the data observed in the feed.