### PR TITLE
Disable pypi artifacts test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         go-version: '1.20'
 
     - name: Run tests
-      run: go test -v ./...
+      run: go test -v -skip TestPyPIArtifactsLive ./...
 
   build-verify:
     runs-on: ubuntu-latest

--- a/pkg/feeds/pypi/pypi_artifacts_test.go
+++ b/pkg/feeds/pypi/pypi_artifacts_test.go
@@ -405,7 +405,7 @@ func TestPyPIArtifactsLive(t *testing.T) {
 	cutoff := time.Now().AddDate(0, 0, -1)
 	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 	if len(errs) != 0 {
-		t.Fatalf("feed.Latest returned error: %v", err)
+		t.Fatalf("feed.Latest returned error: %v", errs)
 	}
 
 	if cutoff == gotCutoff {


### PR DESCRIPTION
The PyPI artifacts feed is broken (see #417)

This change disables the test against the live API to ensure commits can continue to flow.

I also fix a minor bug in the test so I can see the actual error being generated.