### PR TITLE
Expand parameters for container image building

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,11 +1,5 @@
 name: Docker
 on:
-  push:
-    branches:
-      - main
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
   # Run tests for any PRs.
   pull_request:
 
@@ -15,14 +9,9 @@ env:
   IMAGE_NAME: packagefeeds
 
 jobs:
-  # Push image to GitHub Packages.
-  push:
-
+  build-image:
+    name: Build  image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    permissions:
-      packages: write
-      contents: read
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -41,48 +30,3 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Log into registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set container metadata
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
-        id: docker-metadata
-        with:
-          images: docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-          labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
-            org.opencontainers.image.description="This is a container for the Package Feeds process"
-            org.opencontainers.image.title="Package Feeds"
-            org.opencontainers.image.vendor="OpenSSF"
-            org.opencontainers.image.version=${{ github.sha }}
-          flavor: |
-            latest=auto
-          # Using the {{version}} placeholder to automatically detect the version from the git tag
-          # without the prefix "v".
-          # We'll also generate tags for PRs and semver tags.
-          tags: |
-            type=ref,event=tag
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-
-      - name: Build image
-        id: image-build
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: 
-          file: ./Dockerfile
-          tags: ${{ steps.docker-metadata.outputs.tags }}
-          labels: ${{ steps.docker-metadata.outputs.labels }}
-          provenance: true
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-        # only push on tags
-        if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,8 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Test build on x86
+        id: docker_build
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false # Only attempt to build, to verify the Dockerfile is working
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Log into registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
@@ -37,26 +49,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+      - name: Set container metadata
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+        id: docker-metadata
+        with:
+          images: docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.description="This is a container for the Package Feeds process"
+            org.opencontainers.image.title="Package Feeds"
+            org.opencontainers.image.vendor="OpenSSF"
+            org.opencontainers.image.version=${{ github.sha }}
+          flavor: |
+            latest=auto
+          # Using the {{version}} placeholder to automatically detect the version from the git tag
+          # without the prefix "v".
+          # We'll also generate tags for PRs and semver tags.
+          tags: |
+            type=ref,event=tag
+            type=ref,event=pr
+            type=semver,pattern={{version}}
 
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
-
-
+      - name: Build image
+        id: image-build
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: 
+          file: ./Dockerfile
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        # only push on tags
+        if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: packagefeeds
+
+jobs:
+  # Push image to GitHub Packages.
+  push:
+    name: Push
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Log into registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set container metadata
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+        id: docker-metadata
+        with:
+          images: docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.description="This is a container for the Package Feeds process"
+            org.opencontainers.image.title="Package Feeds"
+            org.opencontainers.image.vendor="OpenSSF"
+            org.opencontainers.image.version=${{ github.sha }}
+          flavor: |
+            latest=auto
+          # Using the {{version}} placeholder to automatically detect the version from the git tag
+          # without the prefix "v".
+          # We'll also generate tags for PRs and semver tags.
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+
+      - name: Build image
+        id: image-build
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: 
+          file: ./Dockerfile
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
+        with:
+          cosign-release: 'v2.2.2'
+
       - name: Log into registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
@@ -66,3 +71,7 @@ jobs:
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Sign the image
+        run: |
+          cosign sign --key cosign.key docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME:${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This adds the following:

* Expanded container metadata for the built image.
* multi-architecture builds
* Docker SBOM generation
* Provenance information generation

The intention is to keep a similar set of tags generated as before.

this also separates the pre-existing docker workflow into two jobs:

* One that builds the image on each PR
* Another one intended for the release.

This ensures that we get test coverage for image builds while keeping the GitHub actions permissions minimal.