### PR TITLE
Fix crates

### DIFF
--- a/pkg/feeds/crates/crates.go
+++ b/pkg/feeds/crates/crates.go
@@ -41,7 +41,15 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := httpClient.Get(pkgURL)
+	req, err := http.NewRequest("GET", pkgURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// set headers
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "package-feeds")
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix: add headers when querying crates
    
When running the package feeds for crates i was getting a 403 error, and when debugging response i was seeing that was being  blocked by Cloudflare.
    
Closes: #435