### PR TITLE
Add a user-agent across all feeds.

### DIFF
--- a/pkg/feeds/crates/crates.go
+++ b/pkg/feeds/crates/crates.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -18,7 +19,8 @@ const (
 )
 
 var httpClient = &http.Client{
-	Timeout: 10 * time.Second,
+	Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+	Timeout:   10 * time.Second,
 }
 
 type crates struct {

--- a/pkg/feeds/feed.go
+++ b/pkg/feeds/feed.go
@@ -6,7 +6,11 @@ import (
 	"time"
 )
 
-const schemaVer = "1.1"
+const (
+	schemaVer = "1.1"
+
+	DefaultUserAgent = "package-feeds (github.com/ossf/package-feeds)"
+)
 
 var ErrNoPackagesPolled = errors.New("no packages were successfully polled")
 

--- a/pkg/feeds/goproxy/goproxy.go
+++ b/pkg/feeds/goproxy/goproxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -17,7 +18,10 @@ const (
 	indexPath = "/index"
 )
 
-var httpClient = &http.Client{Timeout: 10 * time.Second}
+var httpClient = &http.Client{
+	Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+	Timeout:   10 * time.Second,
+}
 
 type PackageJSON struct {
 	Path      string `json:"Path"`

--- a/pkg/feeds/maven/maven.go
+++ b/pkg/feeds/maven/maven.go
@@ -68,7 +68,7 @@ func (feed Feed) fetchPackages(page int) ([]Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	indexURL = indexURL + "?repository=maven-central"
+	indexURL += "?repository=maven-central"
 
 	maxRetries := 5
 	retryDelay := 5 * time.Second

--- a/pkg/feeds/maven/maven_test.go
+++ b/pkg/feeds/maven/maven_test.go
@@ -21,13 +21,13 @@ func TestMavenLatest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Maven feed: %v", err)
 	}
-	feed.baseURL = srv.URL + "/api/internal/browse/components"
+	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
 	pkgs, gotCutoff, errs := feed.Latest(cutoff)
 
 	if len(errs) != 0 {
-		t.Fatalf("feed.Latest returned error: %v", err)
+		t.Fatalf("feed.Latest returned error: %v", errs)
 	}
 
 	// Returned cutoff should match the newest package creation time of packages retrieved.
@@ -61,7 +61,7 @@ func TestMavenNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Maven feed: %v", err)
 	}
-	feed.baseURL = srv.URL + "/api/internal/browse/components"
+	feed.baseURL = srv.URL
 
 	cutoff := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/pkg/feeds/npm/npm.go
+++ b/pkg/feeds/npm/npm.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -383,8 +384,11 @@ func New(feedOptions feeds.FeedOptions, eventHandler *events.Handler) (*Feed, er
 		baseURL:          "https://registry.npmjs.org/",
 		options:          feedOptions,
 		client: &http.Client{
-			Transport: tr,
-			Timeout:   45 * time.Second,
+			Transport: &useragent.RoundTripper{
+				UserAgent: feeds.DefaultUserAgent,
+				Parent:    tr,
+			},
+			Timeout: 45 * time.Second,
 		},
 		cache: cache,
 	}, nil

--- a/pkg/feeds/nuget/nuget.go
+++ b/pkg/feeds/nuget/nuget.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -19,8 +20,9 @@ const (
 )
 
 var (
-	httpClient = http.Client{
-		Timeout: 10 * time.Second,
+	httpClient = &http.Client{
+		Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+		Timeout:   10 * time.Second,
 	}
 	errCatalogService = errors.New("error fetching catalog service")
 )

--- a/pkg/feeds/packagist/packagist.go
+++ b/pkg/feeds/packagist/packagist.go
@@ -9,13 +9,15 @@ import (
 	"time"
 
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
 const FeedName = "packagist"
 
 var httpClient = &http.Client{
-	Timeout: 10 * time.Second,
+	Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+	Timeout:   10 * time.Second,
 }
 
 type response struct {

--- a/pkg/feeds/pypi/pypi.go
+++ b/pkg/feeds/pypi/pypi.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -22,7 +23,8 @@ const (
 
 var (
 	httpClient = &http.Client{
-		Timeout: 10 * time.Second,
+		Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+		Timeout:   10 * time.Second,
 	}
 	errInvalidLinkForPackage = errors.New("invalid link provided by pypi API")
 )

--- a/pkg/feeds/pypi/pypi_artifacts.go
+++ b/pkg/feeds/pypi/pypi_artifacts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kolo/xmlrpc"
 
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 )
 
 const (
@@ -30,7 +31,7 @@ func NewArtifactFeed(feedOptions feeds.FeedOptions) (*ArtifactFeed, error) {
 }
 
 func (feed ArtifactFeed) Latest(cutoff time.Time) ([]*feeds.Package, time.Time, []error) {
-	client, err := xmlrpc.NewClient(feed.baseURL, nil)
+	client, err := xmlrpc.NewClient(feed.baseURL, &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent})
 	if err != nil {
 		return nil, cutoff, []error{err}
 	}

--- a/pkg/feeds/rubygems/rubygems.go
+++ b/pkg/feeds/rubygems/rubygems.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/useragent"
 	"github.com/ossf/package-feeds/pkg/utils"
 )
 
@@ -18,7 +19,8 @@ const (
 )
 
 var httpClient = &http.Client{
-	Timeout: 10 * time.Second,
+	Transport: &useragent.RoundTripper{UserAgent: feeds.DefaultUserAgent},
+	Timeout:   10 * time.Second,
 }
 
 type Package struct {

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -1,0 +1,21 @@
+package useragent
+
+import "net/http"
+
+type RoundTripper struct {
+	UserAgent string
+	Parent    http.RoundTripper
+}
+
+func (rt *RoundTripper) RoundTrip(ireq *http.Request) (*http.Response, error) {
+	req := ireq.Clone(ireq.Context())
+	req.Header.Set("User-Agent", rt.UserAgent)
+	return rt.parent().RoundTrip(req)
+}
+
+func (rt *RoundTripper) parent() http.RoundTripper {
+	if rt.Parent != nil {
+		return rt.Parent
+	}
+	return http.DefaultTransport
+}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -1,0 +1,71 @@
+package useragent_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ossf/package-feeds/pkg/useragent"
+)
+
+func TestRoundTripper(t *testing.T) {
+	want := "test user agent string"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("user-agent")
+		if got != want {
+			t.Errorf("User Agent = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := http.Client{
+		Transport: &useragent.RoundTripper{UserAgent: want},
+	}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Get() = %v; want no error", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func TestRoundTripper_Parent(t *testing.T) {
+	want := "test user agent string"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("user-agent")
+		if got != want {
+			t.Errorf("User Agent = %q, want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	calledParent := false
+	c := http.Client{
+		Transport: &useragent.RoundTripper{
+			UserAgent: want,
+			Parent: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				calledParent = true
+				return http.DefaultTransport.RoundTrip(r)
+			}),
+		},
+	}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Get() = %v; want no error", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
+	}
+	if !calledParent {
+		t.Errorf("Failed to call Parent RoundTripper")
+	}
+}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestRoundTripper(t *testing.T) {
+	t.Parallel()
 	want := "test user agent string"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := r.Header.Get("user-agent")
@@ -26,6 +27,7 @@ func TestRoundTripper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get() = %v; want no error", err)
 	}
+	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
 	}
@@ -38,6 +40,7 @@ func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestRoundTripper_Parent(t *testing.T) {
+	t.Parallel()
 	want := "test user agent string"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got := r.Header.Get("user-agent")
@@ -62,6 +65,7 @@ func TestRoundTripper_Parent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get() = %v; want no error", err)
 	}
+	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Get() status = %v; want 200", resp.StatusCode)
 	}


### PR DESCRIPTION
This is to make package-feeds a better API consumer across all endpoints.

This is a follow-up to #436 which specifically adds the header to crates.io.

#435