### PR TITLE
Only deploy when manually triggered.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: 'Deploy with Terraform'
 
-on:
-  push:
-    branches:
-    - main
+on: workflow_dispatch
 
 permissions: read-all
 


### PR DESCRIPTION
Currently whenever a PR is merged into "main" branch the change is deployed.

This change disables the automated behavior, instead requiring a manual trigger of the action.


This is useful because package-feeds is stateless. This means that it is possible a change is missed during an update.

Using a manual trigger reduces the number of deploys, particularly for no-op changes (e.g. workflows), or multiple dependency updates.