### PR TITLE
Add dockers tags that are present on push to main branch, fix IMAGE_NAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
         id: docker-metadata
         with:
-          images: docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          images: docker.pkg.github.com/${{ github.repository }}/${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.description="This is a container for the Package Feeds process"
@@ -55,9 +55,11 @@ jobs:
             latest=auto
           # Using the {{version}} placeholder to automatically detect the version from the git tag
           # without the prefix "v".
-          # We'll also generate tags for PRs and semver tags.
+          # We'll also generate tags for commit sha, main branch changes and semver tags.
           tags: |
+            type=sha
             type=ref,event=tag
+            type=ref,event=branch
             type=semver,pattern={{version}}
 
       - name: Build image
@@ -77,4 +79,4 @@ jobs:
 
       - name: Sign the image
         run: |
-          cosign sign --key cosign.key docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME:${{ steps.meta.outputs.tags }}
+          cosign sign --key cosign.key docker.pkg.github.com/${{ github.repository }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
- Use `${{ env.IMAGE_NAME }}` to inject the env var correctly.
- Add extra tag types to ensure there is at least one present for a push to the main branch.