### PR TITLE
feat: add new http publisher

### DIFF
--- a/pkg/config/scheduledfeed.go
+++ b/pkg/config/scheduledfeed.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ossf/package-feeds/pkg/feeds/rubygems"
 	"github.com/ossf/package-feeds/pkg/publisher"
 	"github.com/ossf/package-feeds/pkg/publisher/gcppubsub"
+	"github.com/ossf/package-feeds/pkg/publisher/httpclientpubsub"
 	"github.com/ossf/package-feeds/pkg/publisher/kafkapubsub"
 	"github.com/ossf/package-feeds/pkg/publisher/stdout"
 )
@@ -153,6 +154,14 @@ func (pc PublisherConfig) ToPublisher(ctx context.Context) (publisher.Publisher,
 			return nil, fmt.Errorf("failed to decode kafkapubsub config: %w", err)
 		}
 		return kafkapubsub.FromConfig(ctx, kafkaConfig)
+	case httpclientpubsub.PublisherType:
+		var httpClientConfig httpclientpubsub.Config
+		err = strictDecode(pc.Config, &httpClientConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode httpclient config: %w", err)
+		}
+		return httpclientpubsub.FromConfig(ctx, httpClientConfig)
+
 	case stdout.PublisherType:
 		return stdout.New(), nil
 	default:

--- a/pkg/config/structs.go
+++ b/pkg/config/structs.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
+	"github.com/ossf/package-feeds/pkg/publisher/httpclientpubsub"
 )
 
 type ScheduledFeedConfig struct {
@@ -23,8 +24,9 @@ type ScheduledFeedConfig struct {
 }
 
 type PublisherConfig struct {
-	Type   string      `mapstructure:"type"`
-	Config interface{} `mapstructure:"config"`
+	Type             string                  `mapstructure:"type"`
+	Config           interface{}             `mapstructure:"config"`
+	HTTPClientConfig httpclientpubsub.Config `mapstructure:"http_client_config"`
 }
 
 type FeedConfig struct {

--- a/pkg/config/structs.go
+++ b/pkg/config/structs.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/ossf/package-feeds/pkg/events"
 	"github.com/ossf/package-feeds/pkg/feeds"
-	"github.com/ossf/package-feeds/pkg/publisher/httpclientpubsub"
 )
 
 type ScheduledFeedConfig struct {
@@ -24,9 +23,8 @@ type ScheduledFeedConfig struct {
 }
 
 type PublisherConfig struct {
-	Type             string                  `mapstructure:"type"`
-	Config           interface{}             `mapstructure:"config"`
-	HTTPClientConfig httpclientpubsub.Config `mapstructure:"http_client_config"`
+	Type   string      `mapstructure:"type"`
+	Config interface{} `mapstructure:"config"`
 }
 
 type FeedConfig struct {

--- a/pkg/publisher/README.md
+++ b/pkg/publisher/README.md
@@ -31,3 +31,11 @@ publisher:
         topic: packagefeeds
 ```
 
+### HTTP client
+
+```
+publisher:
+    type: http-client
+    config:
+      url: "http://target-server:8000/package_feeds_hook"
+```

--- a/pkg/publisher/httpclientpubsub/httpclientpubsub.go
+++ b/pkg/publisher/httpclientpubsub/httpclientpubsub.go
@@ -1,0 +1,60 @@
+package httpclientpubsub
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const PublisherType = "http-client"
+
+var ErrHTTPRequestFailed = errors.New("HTTP request failed")
+
+type Config struct {
+	URL string `mapstructure:"url"`
+}
+
+type HTTPClientPubSub struct {
+	url string
+}
+
+func New(ctx context.Context, url string) (*HTTPClientPubSub, error) {
+	pub := &HTTPClientPubSub{url: url}
+	return pub, nil
+}
+
+func (pub *HTTPClientPubSub) Name() string {
+	return PublisherType
+}
+
+func FromConfig(ctx context.Context, config Config) (*HTTPClientPubSub, error) {
+	return New(ctx, config.URL)
+}
+
+func (pub *HTTPClientPubSub) Send(ctx context.Context, body []byte) error {
+	log.Info("Sending event to HTTP client publisher")
+	// Print the url to the log so that we can see where the event is being sent.
+	req, err := http.NewRequest("POST", pub.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w with status code: %d", ErrHTTPRequestFailed, resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Create a new publisher endpoint, capable of publishing content to an http feed.

Closes: #386