### PR TITLE
Use version in `go.mod` for `setup-go` GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.22'
+        go-version-file: 'go.mod'
 
     - name: Run tests
       run: go test -v -skip TestPyPIArtifactsLive ./...
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.22'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make build


### PR DESCRIPTION
This allows us to test using the supported version we've specified in
our `go.mod` instead of having to manually bump the version in the
workflow files.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
